### PR TITLE
Feature/imports

### DIFF
--- a/doc/Import.md
+++ b/doc/Import.md
@@ -1,0 +1,37 @@
+# Import
+
+## Overview
+
+An import statement imports symbols into its parent. It can import everything from a namespace, or specific symbols. It can also rename a symbol. An import statement cannot reexport a symbol.
+
+## Syntax
+
+The basic syntax of an import statement is the `import` keyword followed by a path.
+
+```
+import path.to.module
+```
+
+Specific symbols from a namespace can also be imported. This can be done by providing a list of the symbols after the import.
+
+```
+import path.to.module (Symbol1, Symbol2)
+```
+
+Symbols can also be renamed with the `as` keyword. Either the module or symbol can be renamed like this. The syntax looks like this:
+
+```
+import path.to.module as ModuleName (Symbol as SymbolName)
+```
+
+## Semantics
+
+- If only a path is provided, every visible symbol in that module will be added to the current scope
+- If a list of symbols is provided, only those are imported
+- If the original module is renamed, then a symbol for it is created and only the explicitly included symbols will be included in scope
+- If the path of an import statement is not an existing module, an error will be thrown
+- If a symbol is provided that doesn't exist, an error will be thrown
+- If a symbol is provided that isn't visible, an error will be thrown
+- If a symbol is provided that shadows another symbol, an error will be thrown
+
+## Future

--- a/doc/Visibility.md
+++ b/doc/Visibility.md
@@ -1,0 +1,25 @@
+# Visibility
+
+## Rules
+
+Public symbols are visible in the root
+Internal symbols are visible in the base module they are defined in
+Fileprivate symbols are visible in the file they are defined in
+Private symbols are visible in the immediate parent they are defined in
+
+## Syntax
+
+A visibility is optionally placed before an item. Each visibility has an associated keyword. When no visibility is specified, the Internal visibility is used.
+
+```
+public func foo() { }
+internal func foo() { }
+fileprivate func foo() { }
+private func foo() { }
+```
+
+## How they work
+
+Visibilities work by calculating a VisibleWithin component. This component calculates the most general entity a symbol is defined on. Whether a symbol is visible from a namespace can be checked by making a list of the ancestors of the namespace, and checking if the symbols VisibleWithin is in that list.
+
+Visibility must be checked when adding a symbol to a SymbolTable, importing a symbol, when finding a static member, and when finding an instance member.

--- a/lib/firefly-ast-lower/src/items/import.rs
+++ b/lib/firefly-ast-lower/src/items/import.rs
@@ -1,0 +1,52 @@
+use firefly_ast::{import::Import as AstImport, Path};
+use firefly_hir::{items::Module, resolve::Symbol, Id, resolve::Import as HirImport};
+
+use crate::AstLowerer;
+
+impl AstLowerer {
+    pub fn lower_import(&mut self, import: &AstImport) {
+        let Some(module) = self.resolve_module(&import.module) else {
+            return;
+        };
+
+        self.context.create(HirImport {
+            id: import.id,
+            namespace: module.as_base()
+        });
+    }
+
+    fn resolve_module(&mut self, path: &Path) -> Option<Id<Module>> {
+        let mut current = self.context.root().as_base();
+
+        for segment in &path.segments {
+            let next = self.context.children(current)
+                .iter()
+                .filter_map(|id| self.context().cast_id::<Symbol>(*id))
+                .find(|sym| self.context().get(*sym).name.name == segment.name.item);
+
+
+            // If the item we're accessing isn't a module,
+            // throw an error
+            if let Some(next_id) = next {
+                if !self.context.has::<Module>(next_id) {
+                    println!("error: {} is not a module", segment.name.item);
+                    return None;
+                }
+
+                current = next_id.as_base();
+                continue;
+            }
+
+            // If the module doesn't exist, throw an error
+            else {
+                println!("error: {} does not exist", segment.name.item);
+                return None;
+            }
+        }
+
+        // Return the module we get
+        let module = self.context.cast_id::<Module>(current)
+            .expect("internal compiler error");
+        Some(module)
+    }
+}

--- a/lib/firefly-ast-lower/src/items/mod.rs
+++ b/lib/firefly-ast-lower/src/items/mod.rs
@@ -1,1 +1,2 @@
 mod func;
+mod import;

--- a/lib/firefly-ast-lower/src/lib.rs
+++ b/lib/firefly-ast-lower/src/lib.rs
@@ -1,5 +1,5 @@
 use firefly_ast::item::Item;
-use firefly_hir::{ty::{HasType, Ty, TyKind}, HirContext};
+use firefly_hir::HirContext;
 use firefly_span::Spanned;
 
 mod items;
@@ -39,11 +39,12 @@ impl AstLowerer {
                 self.lower_func(item, parent);
             }
 
-            Item::StructDef(Spanned { item, .. }) => {
-                // todo: remove this
-                self.context.add_component(item.id, HasType {
-                    ty: Ty::new_unspanned(TyKind::Unit)
-                });
+            Item::StructDef(Spanned { .. }) => {
+
+            }
+
+            Item::Import(Spanned { item, .. }) => {
+                self.lower_import(item);
             }
 
             _ => {}

--- a/lib/firefly-ast-lower/src/link.rs
+++ b/lib/firefly-ast-lower/src/link.rs
@@ -14,7 +14,6 @@ use crate::AstLowerer;
 impl AstLowerer {
     pub fn link_pass(&mut self, ast: &[Item]) {
         let Some(module) = self.get_module(ast) else {
-            println!("error: no module definition found");
             return;
         };
 

--- a/lib/firefly-ast-lower/src/link.rs
+++ b/lib/firefly-ast-lower/src/link.rs
@@ -4,7 +4,7 @@
 
 use firefly_ast::item::Item;
 use firefly_hir::{
-    items::{Module, SourceFile}, resolve::{Passthrough, Symbol}, Entity, Id, Name, Visibility
+    items::{Module, SourceFile}, resolve::{Passthrough, Symbol}, ty::{HasType, Ty, TyKind}, Entity, Id, Name, Visibility
 };
 use firefly_span::Spanned;
 use itertools::Itertools;
@@ -48,6 +48,14 @@ impl AstLowerer {
                     let symbol = Symbol { name, visibility };
                     self.context.add_component(item.id, symbol);
 
+                    self.context.add_component(item.id, HasType {
+                        ty: Ty::new_unspanned(TyKind::Unit)
+                    });
+
+                    item.id.as_base()
+                }
+
+                Item::Import(Spanned { item, .. }) => {
                     item.id.as_base()
                 }
 

--- a/lib/firefly-ast-lower/src/resolve.rs
+++ b/lib/firefly-ast-lower/src/resolve.rs
@@ -94,7 +94,6 @@ impl AstLowerer {
             current = parent;
         }
 
-
         return false;
     }
 }

--- a/lib/firefly-ast/src/import.rs
+++ b/lib/firefly-ast/src/import.rs
@@ -1,0 +1,19 @@
+use crate::{Name, Path};
+
+#[derive(Debug)]
+pub struct Import {
+    pub module: Path,
+    pub alias: Option<Name>,
+    pub symbol_list: Option<ImportSymbolList>,
+}
+
+#[derive(Debug)]
+pub struct ImportSymbolList {
+    pub symbols: Vec<ImportSymbol>
+}
+
+#[derive(Debug)]
+pub struct ImportSymbol {
+    pub name: Name,
+    pub alias: Option<Name>
+}

--- a/lib/firefly-ast/src/import.rs
+++ b/lib/firefly-ast/src/import.rs
@@ -1,7 +1,11 @@
+use firefly_hir::Id;
+use firefly_hir::resolve::Import as HirImport;
+
 use crate::{Name, Path};
 
 #[derive(Debug)]
 pub struct Import {
+    pub id: Id<HirImport>,
     pub module: Path,
     pub alias: Option<Name>,
     pub symbol_list: Option<ImportSymbolList>,
@@ -16,4 +20,15 @@ pub struct ImportSymbolList {
 pub struct ImportSymbol {
     pub name: Name,
     pub alias: Option<Name>
+}
+
+impl Import {
+    pub fn new(module: Path, alias: Option<Name>, symbol_list: Option<ImportSymbolList>) -> Self {
+        Self {
+            id: Id::default(),
+            module,
+            alias,
+            symbol_list,
+        }
+    }
 }

--- a/lib/firefly-ast/src/item.rs
+++ b/lib/firefly-ast/src/item.rs
@@ -1,11 +1,12 @@
 use firefly_span::Spanned;
 
-use crate::{func::Func, module::Module, struct_def::{Field, StructDef}};
+use crate::{func::Func, import::Import, module::Module, struct_def::{Field, StructDef}};
 
 #[derive(Debug)]
 pub enum Item {
     Func(Spanned<Func>),
     Field(Spanned<Field>),
     StructDef(Spanned<StructDef>),
-    Module(Spanned<Module>)
+    Module(Spanned<Module>),
+    Import(Spanned<Import>)
 }

--- a/lib/firefly-ast/src/lib.rs
+++ b/lib/firefly-ast/src/lib.rs
@@ -6,6 +6,7 @@ pub mod func;
 pub mod item;
 pub mod value;
 pub mod module;
+pub mod import;
 pub mod struct_def;
 
 pub type Name = Spanned<String>;

--- a/lib/firefly-hir/src/context/mod.rs
+++ b/lib/firefly-hir/src/context/mod.rs
@@ -1,7 +1,7 @@
 mod iter;
 mod display;
 
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Debug};
 
 use display::DisplayContext;
 
@@ -168,10 +168,17 @@ impl HirContext {
     pub fn try_get_computed<C: ComputedComponent>(&mut self, id: Id<impl Component>) -> Option<&C>
     where
         Self: AccessComponent<C>,
+        C: Debug
     {
         // todo!: this code is really hacky, but
         // its the only way I could get the borrow tracker to work
         let entity_id = id.as_base();
+
+        let kind = self.get::<Entity>(id.as_base()).kind;
+        println!("{kind:?} {entity_id:?}");
+
+        let component = <Self as AccessComponent<C>>::get_components(self).get(&entity_id);
+        //println!("{component:?}");
 
         if <Self as AccessComponent<C>>::get_components(self).contains_key(&entity_id) {
             return <Self as AccessComponent<C>>::get_components(self).get(&entity_id);

--- a/lib/firefly-hir/src/context/mod.rs
+++ b/lib/firefly-hir/src/context/mod.rs
@@ -174,12 +174,6 @@ impl HirContext {
         // its the only way I could get the borrow tracker to work
         let entity_id = id.as_base();
 
-        let kind = self.get::<Entity>(id.as_base()).kind;
-        println!("{kind:?} {entity_id:?}");
-
-        let component = <Self as AccessComponent<C>>::get_components(self).get(&entity_id);
-        //println!("{component:?}");
-
         if <Self as AccessComponent<C>>::get_components(self).contains_key(&entity_id) {
             return <Self as AccessComponent<C>>::get_components(self).get(&entity_id);
         }

--- a/lib/firefly-hir/src/resolve/import.rs
+++ b/lib/firefly-hir/src/resolve/import.rs
@@ -1,9 +1,27 @@
-use crate::{Entity, EntityKind, Id};
+use crate::{Entity, EntityKind, Id, Name};
+
+#[derive(Clone, Debug)]
+pub struct ImportRequest {
+    pub name: Name,
+    pub alias: Option<Name>
+}
 
 #[derive(Clone, Debug)]
 pub struct Import {
     pub id: Id<Import>,
     pub namespace: Id<Entity>,
+    pub alias: Option<Name>,
+    pub symbols: Option<Vec<ImportRequest>>
 }
 
 component!(base(EntityKind::Import) imports: Import);
+
+impl Import {
+    pub fn import(id: Id<Import>, namespace: Id<Entity>) -> Self {
+        Self { id, namespace, alias: None, symbols: None }
+    }
+
+    pub fn import_aliased(id: Id<Import>, namespace: Id<Entity>, alias: Name) -> Self {
+        Self { id, namespace, alias: Some(alias), symbols: None }
+    }
+}

--- a/lib/firefly-hir/src/resolve/symbol_table.rs
+++ b/lib/firefly-hir/src/resolve/symbol_table.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 
 use itertools::Itertools;
 

--- a/lib/firefly-hir/src/resolve/symbol_table.rs
+++ b/lib/firefly-hir/src/resolve/symbol_table.rs
@@ -1,8 +1,10 @@
 use std::collections::{HashMap, VecDeque};
 
+use itertools::Itertools;
+
 use crate::{ComputedComponent, Entity, HirContext, Id};
 
-use super::{Import, Namespace, Symbol, VisibleWithin};
+use super::{Import, ImportRequest, Namespace, Symbol, VisibleWithin};
 
 /// Stores a delta so that scopes can quickly be restored
 #[derive(Clone, Debug)]
@@ -62,14 +64,20 @@ component!(symbol_tables: SymbolTable);
 
 impl ComputedComponent for SymbolTable {
     fn compute(entity: Id<crate::Entity>, context: &mut HirContext) -> Option<Self> {
-        let mut symbol_table = SymbolTable::default();
+        let mut symbol_table =
+            context.parent(entity)
+                   .and_then(|parent| context.try_get_computed::<SymbolTable>(parent))
+                   .cloned()
+                   .unwrap_or_default();
+        
+        symbol_table.push_scope();
 
         // Traverse the namespace hierarchy
         // and add the symbols to the symbol table
         let mut entities_to_traverse = VecDeque::new();
-        entities_to_traverse.push_back((entity, true));
+        entities_to_traverse.push_back(entity);
 
-        while let Some((some_namespace_id, follow_imports)) = entities_to_traverse.pop_front() {
+        while let Some(some_namespace_id) = entities_to_traverse.pop_front() {
             let namespace = context.try_get_computed::<Namespace>(some_namespace_id)?;
             let symbols = namespace.symbols.clone();
 
@@ -97,17 +105,19 @@ impl ComputedComponent for SymbolTable {
                 symbol_table.insert(name, symbol_id);
             }
 
-            if follow_imports {
-                // Go through imports and add them to the symbol table
-                context.children(some_namespace_id)
-                    .iter()
-                    .cloned()
-                    .filter_map(|id| context.try_get::<Import>(id))
-                    .for_each(|import| entities_to_traverse.push_back((import.namespace, false)));
+            // Go through imports and add them to the symbol table
+            let imports = context.children(some_namespace_id)
+                .iter()
+                .cloned()
+                .filter_map(|id| context.cast_id::<Import>(id))
+                .collect_vec();
 
-                if let Some(parent_id) = context.get(some_namespace_id.as_base()).parent {
-                    entities_to_traverse.push_back((parent_id, follow_imports));
-                }
+            for import in imports {
+                Self::import(import, &mut symbol_table, context)
+            }
+
+            if let Some(parent_id) = context.get(some_namespace_id.as_base()).parent {
+                entities_to_traverse.push_back(parent_id);
             }
         }
 
@@ -116,6 +126,116 @@ impl ComputedComponent for SymbolTable {
 }
 
 impl SymbolTable {
+    fn import(import: Id<Import>, symbol_table: &mut SymbolTable, context: &mut HirContext) {
+        let import = context.get(import);
+        let namespace_id = import.namespace;
+
+        let symbols = import.symbols.clone();
+
+        if let Some(alias) = &import.alias {
+            let Some(symbol) = context.cast_id::<Symbol>(namespace_id) else {
+                panic!("internal compiler error: module has no symbol");
+            };
+            symbol_table.insert(alias.name.clone(), symbol);
+        }
+        else if symbols.is_none() {
+            Self::add_all_symbols(namespace_id, symbol_table, context);
+        }
+
+        if let Some(symbols) = symbols {
+            Self::add_specific_symbols(namespace_id, symbols, symbol_table, context);
+        }
+    }
+
+    fn add_all_symbols(namespace_id: Id<Entity>, symbol_table: &mut SymbolTable, context: &mut HirContext) {
+        let Some(namespace) = context.try_get_computed::<Namespace>(namespace_id) else {
+            panic!("internal compiler error: no namespace for import")
+        };
+        let symbols = namespace.symbols.clone();
+
+        // We're looking at 4-6 ancestors on average, so its faster to use
+        // a Vec than a HashSet
+        let ancestors = Self::get_ancestors(namespace_id.as_base(), context);
+
+        // Add the symbols if they don't already exist
+        // We support shadowing, so we don't need to check for duplicates
+        for symbol_id in symbols.into_iter() {
+            // Where is the symbol visible from?
+            let Some(VisibleWithin(scope)) = context.try_get_computed::<VisibleWithin>(symbol_id) else {
+                panic!("internal compiler error: couldn't calculate visibility");
+            };
+
+            // If we aren't in a scope where the symbol is visible,
+            // don't add it
+            if !ancestors.contains(&scope) {
+                continue;
+            }
+
+            let symbol = context.get(symbol_id);
+            let name = symbol.name.name.clone();
+
+            symbol_table.insert(name, symbol_id);
+        }
+    }
+
+    fn add_specific_symbols(namespace_id: Id<Entity>, symbols: Vec<ImportRequest>, symbol_table: &mut SymbolTable, context: &mut HirContext) {
+        // We need to match symbols to their import symbols
+        // Create a map to do this on O(n) time
+        let mut symbol_map = HashMap::new();
+
+        for symbol in symbols {
+            if symbol_map.contains_key(&symbol.name.name) {
+                println!("error: already imported {}", symbol.name.name);
+            }
+
+            symbol_map.insert(symbol.name.name.clone(), symbol);
+        }
+
+        let Some(namespace) = context.try_get_computed::<Namespace>(namespace_id) else {
+            panic!("internal compiler error: no namespace for import")
+        };
+        let symbols = namespace.symbols.clone();
+
+        // We're looking at 4-6 ancestors on average, so its faster to use
+        // a Vec than a HashSet
+        let ancestors = Self::get_ancestors(namespace_id.as_base(), context);
+
+        // Add the symbols if they don't already exist
+        // We support shadowing, so we don't need to check for duplicates
+        for symbol_id in symbols.into_iter() {
+            let symbol = context.get(symbol_id);
+            let mut name = symbol.name.name.clone();
+
+            // Check if we are looking for that symbol
+            let Some(symbol_req) = symbol_map.remove(&name) else {
+                continue;
+            };
+
+            // If there's an alias, add that symbol
+            if let Some(alias) = symbol_req.alias {
+                name = alias.name.clone();
+            }
+
+            // Where is the symbol visible from?
+            let Some(VisibleWithin(scope)) = context.try_get_computed::<VisibleWithin>(symbol_id) else {
+                panic!("internal compiler error: couldn't calculate visibility");
+            };
+
+            // If we aren't in a scope where the symbol is visible,
+            // don't add it
+            if !ancestors.contains(&scope) {
+                println!("error: symbol {name} isn't visible in the current context");
+            }
+
+            symbol_table.insert(name, symbol_id);
+        }
+
+        // Check that we imported all requested symbols
+        for ImportRequest { name, .. } in symbol_map.values() {
+            println!("error: couldn't find {} in import", &name.name);
+        }
+    }
+
     /// Return a list of the ancestors of an entity
     fn get_ancestors(entity: Id<Entity>, context: &HirContext) -> Vec<Id<Entity>> {
         let mut ancestors = vec![entity];
@@ -125,7 +245,6 @@ impl SymbolTable {
             ancestors.push(parent);
             current = parent;
         }
-
 
         return ancestors;
     }

--- a/lib/firefly-lang/src/lib.rs
+++ b/lib/firefly-lang/src/lib.rs
@@ -22,7 +22,7 @@ pub fn create_lang_module(context: &mut HirContext) {
     let _float = create("float", typealias(TyKind::Float), lang_id, context);
 
     let root = context.root();
-    let import_id = context.create(Import { id: Default::default(), namespace: lang_id.as_base() });
+    let import_id = context.create(Import::import(Default::default(), lang_id.as_base()));
     context.link(root, import_id);
 }
 

--- a/lib/firefly-parser/src/lexer.rs
+++ b/lib/firefly-parser/src/lexer.rs
@@ -49,6 +49,9 @@ pub enum Token<'a> {
     #[token("return")]
     ReturnKw,
 
+    #[token("as")]
+    AsKw,
+
     // Symbols
     #[token("(")]
     OpenParen,

--- a/lib/firefly-parser/src/parser.lalrpop
+++ b/lib/firefly-parser/src/parser.lalrpop
@@ -88,11 +88,11 @@ UnspannedModule: Module = {
 
 Import = { Spanned<UnspannedImport> };
 UnspannedImport: Import = {
-    "import" <module: Path> <alias: Rename?> <symbol_list: ImportSymbolList?> ";"? => Import {
+    "import" <module: Path> <alias: Rename?> <symbol_list: ImportSymbolList?> ";"? => Import::new(
         module,
         alias,
         symbol_list
-    }
+    )
 }
 
 ImportSymbolList: ImportSymbolList = {

--- a/lib/firefly-parser/src/parser.lalrpop
+++ b/lib/firefly-parser/src/parser.lalrpop
@@ -8,6 +8,7 @@ use firefly_ast::{
     item::Item,
     struct_def::{StructDef, Field},
     module::Module,
+    import::{Import, ImportSymbolList, ImportSymbol}
 };
 use crate::{
     error::LexerError,
@@ -43,6 +44,8 @@ extern {
 
         "return" => Token::ReturnKw,
 
+        "as" => Token::AsKw,
+
         "integer" => Token::IntegerLiteral(<&'source str>),
 
         // Symbols
@@ -70,6 +73,7 @@ Item: Item = {
     <Function> => Item::Func(<>),
     <Field> => Item::Field(<>),
     <Module> => Item::Module(<>),
+    <Import> => Item::Import(<>),
 }
 
 // Modules
@@ -78,6 +82,29 @@ UnspannedModule: Module = {
     "module" <path: Path> ";"? => Module {
         path
     }
+}
+
+// Imports
+
+Import = { Spanned<UnspannedImport> };
+UnspannedImport: Import = {
+    "import" <module: Path> <alias: Rename?> <symbol_list: ImportSymbolList?> ";"? => Import {
+        module,
+        alias,
+        symbol_list
+    }
+}
+
+ImportSymbolList: ImportSymbolList = {
+    "(" <symbols: CommaList<ImportSymbol>> ")" => ImportSymbolList { symbols }
+}
+
+ImportSymbol: ImportSymbol = {
+    <name: Name> <alias: Rename?> => ImportSymbol { name, alias }
+}
+
+Rename: Spanned<String> = {
+    "as" <name: Name> => name
 }
 
 // Structs

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,11 @@ use firefly_ast_lower::AstLowerer;
 use itertools::Itertools;
 
 fn main() {
-    let args = Args::parse();
+    let args = Args::parse_from(&[
+        "",
+        "tests/Import/Defs.fly",
+        "tests/Import/UsesList.fly"
+    ]);
 
     // Load files into the source map
     let source_map = firefly_span::SourceMap::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,11 +8,7 @@ use firefly_ast_lower::AstLowerer;
 use itertools::Itertools;
 
 fn main() {
-    let args = Args::parse_from(&[
-        "",
-        "tests/Import/Defs.fly",
-        "tests/Import/UsesList.fly"
-    ]);
+    let args = Args::parse();
 
     // Load files into the source map
     let source_map = firefly_span::SourceMap::new();

--- a/tests/Import/Defs.fly
+++ b/tests/Import/Defs.fly
@@ -1,0 +1,5 @@
+module Test.Defs;
+
+public struct Foo {}
+internal struct Bar {}
+private struct Baz {}

--- a/tests/Import/Parse.fly
+++ b/tests/Import/Parse.fly
@@ -1,0 +1,7 @@
+module Test
+
+import std.fs
+import std.fs as fs
+import std.fs (File, open)
+import std.fs as fs (File, open)
+import std.fs (File, open as OpenFile)

--- a/tests/Import/Uses.fly
+++ b/tests/Import/Uses.fly
@@ -1,0 +1,9 @@
+module Test.Uses
+
+import Test.Defs
+
+func foo(
+    a: Foo,
+    b: Bar,
+    c: Baz
+) { }

--- a/tests/Import/UsesAs.fly
+++ b/tests/Import/UsesAs.fly
@@ -1,0 +1,9 @@
+module Test.Uses
+
+import Test.Defs as FooBar
+
+func foo(
+    a: FooBar.Foo,
+    b: FooBar.Bar,
+    c: FooBar.Baz
+) { }

--- a/tests/Import/UsesList.fly
+++ b/tests/Import/UsesList.fly
@@ -1,0 +1,9 @@
+module Test.Uses
+
+import Test.Defs (Foo as Foo2, Baz)
+
+func foo(
+    a: Foo2,
+    b: Bar,
+    c: Baz
+) { }

--- a/todo.md
+++ b/todo.md
@@ -9,12 +9,13 @@
 - [x] Add modules
 - [x] Add visibilities
 - [ ] Add imports
-- [ ] Add structs
 - [ ] Add strings
+- [ ] Add structs
 - [ ] Add members
 - [ ] Add globals
 - [ ] Add function calls
 - [ ] Add system functions
+- [ ] Add control flow
 
 # Error Handling
 
@@ -26,3 +27,7 @@
 
 - [ ] Lower HIR to VM
 - [ ] Run the VM
+
+# Bugs
+
+- [ ] Add invisible items but mark them as such

--- a/todo.md
+++ b/todo.md
@@ -8,7 +8,7 @@
 - [x] Rename bindings to locals
 - [x] Add modules
 - [x] Add visibilities
-- [ ] Add imports
+- [x] Add imports
 - [ ] Add strings
 - [ ] Add structs
 - [ ] Add members
@@ -16,6 +16,8 @@
 - [ ] Add function calls
 - [ ] Add system functions
 - [ ] Add control flow
+
+# Testing framework
 
 # Error Handling
 

--- a/todo.md
+++ b/todo.md
@@ -7,7 +7,7 @@
 - [x] Add values
 - [x] Rename bindings to locals
 - [x] Add modules
-- [ ] Add visibilities
+- [x] Add visibilities
 - [ ] Add imports
 - [ ] Add structs
 - [ ] Add strings


### PR DESCRIPTION
# Import

## Overview

An import statement imports symbols into its parent. It can import everything from a namespace, or specific symbols. It can also rename a symbol. An import statement cannot reexport a symbol.

## Syntax

The basic syntax of an import statement is the `import` keyword followed by a path.

```
import path.to.module
```

Specific symbols from a namespace can also be imported. This can be done by providing a list of the symbols after the import.

```
import path.to.module (Symbol1, Symbol2)
```

Symbols can also be renamed with the `as` keyword. Either the module or symbol can be renamed like this. The syntax looks like this:

```
import path.to.module as ModuleName (Symbol as SymbolName)
```

## Semantics

- If only a path is provided, every visible symbol in that module will be added to the current scope
- If a list of symbols is provided, only those are imported
- If the original module is renamed, then a symbol for it is created and only the explicitly included symbols will be included in scope
- If the path of an import statement is not an existing module, an error will be thrown
- If a symbol is provided that doesn't exist, an error will be thrown
- If a symbol is provided that isn't visible, an error will be thrown
- If a symbol is provided that shadows another symbol, an error will be thrown

## Future