### PR TITLE
Feature/control flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,7 @@ dependencies = [
 name = "firefly-hir"
 version = "0.1.0"
 dependencies = [
+ "firefly-error-messages",
  "firefly-errors",
  "firefly-span",
  "itertools 0.13.0",

--- a/docs/features/ControlFlow.md
+++ b/docs/features/ControlFlow.md
@@ -28,6 +28,64 @@ An if statement is a value with the type `()`
 
 ## While
 
+Runs a block of code while a condition is true. If the condition is initially false, never runs the code.
+
+### Syntax
+
+```firefly
+while condition {
+
+}
+
+label: while condition {
+
+}
+```
+
+### Semantics
+
+- Throws an error if condition is not a boolean
+- Runs the code while the condition is true
+- Evaluates the condition on each run-through
+- Able to be exited early with the break keyword
+- Using a label allows a specific loop to be exited
+- Labels are available within their block
+- Labels shadow other, outside labels with the same name
+
+## Break
+
+A break statement exits from a loop. It can specify which loop to exit, or else it will exit the innermost loop.
+
+### Syntax
+
+```firefly
+break
+break label
+```
+
+### Semantics
+
+- If it isn't in a loop, an error is thrown
+- If the label doesn't exist, an error is thrown
+- A break value has the never type
+
+## Break
+
+A continue statement moves to the next iteration of a loop. It can specify which loop to continue, or else it will continue the innermost loop.
+
+### Syntax
+
+```firefly
+continue
+continue label
+```
+
+### Semantics
+
+- If it isn't in a loop, an error is thrown
+- If the label doesn't exist, an error is thrown
+- A continue value has the never type
+
 ## Return
 
 Returns from the function early, possibly returning a value.

--- a/docs/features/ControlFlow.md
+++ b/docs/features/ControlFlow.md
@@ -2,6 +2,30 @@
 
 ## If
 
+Checks a condition, running one block of code if it is true and another if it is false.
+
+### Syntax
+
+```firefly
+if condition {
+    // run this code
+}
+else if other_condition {
+    // run this code
+}
+else {
+    // run this code
+}
+```
+
+### Semantics
+
+If the condition isn't a boolean, throw an error
+After the if statement, an else statement can run a code block or another if statement
+The first if statement which's condition is true runs
+An if statement is a value with the type `()`
+
+
 ## While
 
 ## Return

--- a/docs/features/ControlFlow.md
+++ b/docs/features/ControlFlow.md
@@ -1,0 +1,22 @@
+# Control Flow
+
+## If
+
+## While
+
+## Return
+
+Returns from the function early, possibly returning a value.
+
+### Syntax
+
+```firefly
+return
+return value
+```
+
+### Semantics
+
+If the value returned is omitted, it will be assumed to be the unit tuple `()`.
+The type of the value returned must match the return type of the function it is called in
+Outside of a function, a return statement can't be used

--- a/docs/features/Errors.md
+++ b/docs/features/Errors.md
@@ -11,6 +11,11 @@ E0104: Symbol not a type
 E0105: Symbol not a value
     Tried to use type as a value
 
+E0120: Value doesn't have children
+    Tried to get a child of a value without children
+E0121: Member not found
+E0122:
+
 E020x: String Errors
 
 E0201: Invalid Escape Code
@@ -23,3 +28,24 @@ E0106: Not a module
 E0150: Module declaration inside item
 E0151: MultipleModulesFound
 E0152: No Module Found
+
+E016x: Import errors
+
+E0160: Multiple definitions found for
+E0161: Item `` is not visible in the current context
+E0162: Item `` is not found
+
+E030x: Break/Continue errors
+
+E0301: Break outside of loop
+E0302: Can't find loop with label `` for break
+E0303: Continue outside of loop
+E0304: Can't find loop with label `` for continue
+
+E05xx: Type errors
+
+E0501: Can't call a value of type ...
+
+E06xx: Declaration errors
+
+E0601: Global variable must have a default value

--- a/lib/firefly-ast-lower/src/errors/decl.rs
+++ b/lib/firefly-ast-lower/src/errors/decl.rs
@@ -1,0 +1,21 @@
+use firefly_ast::Name;
+use firefly_error_messages::DiagnosticMessage;
+use firefly_errors::diagnostic::{Diagnostic, DiagnosticId, Level};
+use firefly_hir::{HirContext, IntoDiagnostic};
+
+pub enum DeclarationError {
+    GlobalVarNoDefault(Name),
+}
+
+impl IntoDiagnostic for DeclarationError {
+    fn into_diagnostic(&self, _: &HirContext) -> Diagnostic {
+        match self {
+            DeclarationError::GlobalVarNoDefault(name) => {
+                Diagnostic::new(Level::Error,
+                    DiagnosticMessage::Str(format!("Global variable `{}` has no default", name.item))
+                ).with_error_code(DiagnosticId::new("E0601"))
+                 .with_source(name.span)
+            }
+        }
+    }
+}

--- a/lib/firefly-ast-lower/src/errors/mod.rs
+++ b/lib/firefly-ast-lower/src/errors/mod.rs
@@ -1,7 +1,13 @@
 mod module;
 mod string;
 mod symbol;
+mod value;
+mod decl;
+mod ty;
 
 pub use module::*;
 pub use string::*;
 pub use symbol::*;
+pub use value::*;
+pub use decl::*;
+pub use ty::*;

--- a/lib/firefly-ast-lower/src/errors/symbol.rs
+++ b/lib/firefly-ast-lower/src/errors/symbol.rs
@@ -1,7 +1,7 @@
 use firefly_ast::Name;
 use firefly_error_messages::DiagnosticMessage;
 use firefly_errors::diagnostic::{Diagnostic, DiagnosticId, Level};
-use firefly_hir::{HirContext, IntoDiagnostic};
+use firefly_hir::{value::Value, HirContext, IntoDiagnostic};
 use firefly_span::Span;
 
 pub enum SymbolError {
@@ -11,6 +11,10 @@ pub enum SymbolError {
 
     NotAType(Span, Span),
     NotAValue(Span, Span),
+
+    NoMembersOf(Value),
+    NoMemberOn(Name, Value),
+    MemberNotAValue(Name, Span),
 }
 
 impl IntoDiagnostic for SymbolError {
@@ -43,6 +47,22 @@ impl IntoDiagnostic for SymbolError {
                 Diagnostic::new(Level::Error, DiagnosticMessage::Str(format!("symbol is not a value")))
                     .with_error_code(DiagnosticId::new("E0105"))
                     .with_source(*access)
+                    .with_source(*decl)
+            }
+            SymbolError::NoMembersOf(value) => {
+                Diagnostic::new(Level::Error, DiagnosticMessage::Str(format!("value of type `` has no members")))
+                    .with_error_code(DiagnosticId::new("E0120"))
+                    .with_source(value.span)
+            }
+            SymbolError::NoMemberOn(name, _) => {
+                Diagnostic::new(Level::Error, DiagnosticMessage::Str(format!("member `{}` not found for value of type ``", name.item)))
+                    .with_error_code(DiagnosticId::new("E0121"))
+                    .with_source(name.span)
+            }
+            SymbolError::MemberNotAValue(name, decl) => {
+                Diagnostic::new(Level::Error, DiagnosticMessage::Str(format!("member `{}` is not a value", name.item)))
+                    .with_error_code(DiagnosticId::new("E0122"))
+                    .with_source(name.span)
                     .with_source(*decl)
             }
         }

--- a/lib/firefly-ast-lower/src/errors/ty.rs
+++ b/lib/firefly-ast-lower/src/errors/ty.rs
@@ -1,0 +1,21 @@
+use firefly_error_messages::DiagnosticMessage;
+use firefly_errors::diagnostic::{Diagnostic, DiagnosticId, Level};
+use firefly_hir::IntoDiagnostic;
+use firefly_span::Span;
+
+pub enum TypeError {
+    CantCall(Span)
+}
+
+impl IntoDiagnostic for TypeError {
+    fn into_diagnostic(&self, _: &firefly_hir::HirContext) -> Diagnostic {
+        match self {
+            Self::CantCall(span) => {
+                Diagnostic::new(Level::Error,
+                    DiagnosticMessage::Str(format!("Value can't be called",))
+                ).with_error_code(DiagnosticId::new("E0501"))
+                 .with_source(*span)
+            }
+        }
+    }
+}

--- a/lib/firefly-ast-lower/src/errors/value.rs
+++ b/lib/firefly-ast-lower/src/errors/value.rs
@@ -1,0 +1,43 @@
+use firefly_ast::Name;
+use firefly_error_messages::DiagnosticMessage;
+use firefly_errors::diagnostic::{Diagnostic, DiagnosticId, Level};
+use firefly_hir::IntoDiagnostic;
+use firefly_span::Span;
+
+pub enum ValueError {
+    BreakOutsideLoop(Span),
+    UndefinedBreakLabel(Name),
+    ContinueOutsideLoop(Span),
+    UndefinedContinueLabel(Name)
+}
+
+impl IntoDiagnostic for ValueError {
+    fn into_diagnostic(&self, _context: &firefly_hir::HirContext) -> Diagnostic {
+        match self {
+            ValueError::BreakOutsideLoop(span) => {
+                Diagnostic::new(Level::Error,
+                    DiagnosticMessage::Str(format!("Break outside of loop",))
+                ).with_error_code(DiagnosticId::new("E0301"))
+                 .with_source(*span)
+            }
+            ValueError::UndefinedBreakLabel(name) => {
+                Diagnostic::new(Level::Error,
+                    DiagnosticMessage::Str(format!("Use of undefined label `{}` in break", name.item))
+                ).with_error_code(DiagnosticId::new("E0302"))
+                 .with_source(name.span)
+            }
+            ValueError::ContinueOutsideLoop(span) => {
+                Diagnostic::new(Level::Error,
+                    DiagnosticMessage::Str(format!("Continue outside of loop",))
+                ).with_error_code(DiagnosticId::new("E0303"))
+                 .with_source(*span)
+            }
+            ValueError::UndefinedContinueLabel(name) => {
+                Diagnostic::new(Level::Error,
+                    DiagnosticMessage::Str(format!("Use of undefined label `{}` in continue", name.item))
+                ).with_error_code(DiagnosticId::new("E0304"))
+                 .with_source(name.span)
+            }
+        }
+    }
+}

--- a/lib/firefly-ast-lower/src/items/global.rs
+++ b/lib/firefly-ast-lower/src/items/global.rs
@@ -1,7 +1,7 @@
 use firefly_ast::struct_def::Field;
 use firefly_hir::{items::{Field as HirField, Global, SourceFile}, resolve::SymbolTable, value::{HasValue, HasValueIn, Value, ValueKind}, Entity, Id};
 
-use crate::{AstLowerer, Lower, SymbolDesc};
+use crate::{errors::DeclarationError, AstLowerer, Lower, SymbolDesc};
 
 impl Lower for Field {
     fn id(&self) -> Id<Entity> {
@@ -55,7 +55,7 @@ impl Lower for Field {
         };
 
         let Some(default) = &self.default else {
-            println!("error: global does not have a default value");
+            lowerer.emit(DeclarationError::GlobalVarNoDefault(self.name.clone()));
             return;
         };
 

--- a/lib/firefly-ast-lower/src/items/global.rs
+++ b/lib/firefly-ast-lower/src/items/global.rs
@@ -50,7 +50,7 @@ impl Lower for Field {
 
         let id = unsafe { self.id.cast::<Global>() };
 
-        let Some(symbol_table) = lowerer.context_mut().try_get_computed::<SymbolTable>(parent).cloned() else {
+        let Some(mut symbol_table) = lowerer.context_mut().try_get_computed::<SymbolTable>(parent).cloned() else {
             panic!("internal compiler error: parent is not a namespace")
         };
 
@@ -60,7 +60,7 @@ impl Lower for Field {
         };
 
         let ty = lowerer.lower_ty(&self.ty, parent, &symbol_table);
-        let default_value = lowerer.lower_value(&default, parent, &symbol_table);
+        let default_value = lowerer.lower_value(&default, parent, &mut symbol_table);
 
         lowerer.context_mut().create(Global { id, ty, default_value });
     }

--- a/lib/firefly-ast-lower/src/labels.rs
+++ b/lib/firefly-ast-lower/src/labels.rs
@@ -1,0 +1,32 @@
+use firefly_hir::{stmt::CodeBlock, Id, Name};
+
+pub struct LoopLabel {
+    pub label: Option<Name>,
+    pub code_block: Id<CodeBlock>,
+}
+
+pub struct LabelStack {
+
+}
+
+impl LabelStack {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn push(&mut self, label: Option<Name>, code_block: Id<CodeBlock>) {
+
+    }
+
+    pub fn pop(&mut self) {
+
+    }
+
+    pub fn last(&self) -> Option<&LoopLabel> {
+        None
+    }
+
+    pub fn find(&self, name: &str) -> Option<&LoopLabel> {
+        None
+    }
+}

--- a/lib/firefly-ast-lower/src/labels.rs
+++ b/lib/firefly-ast-lower/src/labels.rs
@@ -6,27 +6,35 @@ pub struct LoopLabel {
 }
 
 pub struct LabelStack {
-
+    stack: Vec<LoopLabel>
 }
 
 impl LabelStack {
     pub fn new() -> Self {
-        Self {}
+        Self { stack: Vec::new() }
     }
 
     pub fn push(&mut self, label: Option<Name>, code_block: Id<CodeBlock>) {
-
+        self.stack.push(LoopLabel { label, code_block });
     }
 
     pub fn pop(&mut self) {
-
+        self.stack.pop();
     }
 
     pub fn last(&self) -> Option<&LoopLabel> {
-        None
+        self.stack.last()
     }
 
     pub fn find(&self, name: &str) -> Option<&LoopLabel> {
-        None
+        for loop_label in self.stack.iter().rev() {
+            let Some(label) = &loop_label.label else { continue };
+
+            if label.name == name {
+                return Some(loop_label);
+            }
+        }
+
+        return None;
     }
 }

--- a/lib/firefly-ast-lower/src/lib.rs
+++ b/lib/firefly-ast-lower/src/lib.rs
@@ -4,6 +4,7 @@ use firefly_ast::{item::Item, Visibility};
 use firefly_errors::emitter::Emitter;
 use firefly_hir::{ty::Ty, value::Value, Entity, HirContext, Id, IntoDiagnostic};
 use firefly_span::{Span, Spanned};
+use labels::LabelStack;
 
 mod items;
 mod link;
@@ -13,10 +14,12 @@ mod util;
 mod stmt;
 mod value;
 pub mod errors;
+mod labels;
 
 pub struct AstLowerer {
     context: HirContext,
     pub(crate) self_value: Option<Value>,
+    pub(crate) label_stack: LabelStack,
 }
 
 impl AstLowerer {
@@ -24,7 +27,7 @@ impl AstLowerer {
         let mut context = HirContext::new(&emitter);
         firefly_lang::create_lang_module(&mut context);
 
-        let mut lowerer = Self { context, self_value: None };
+        let mut lowerer = Self { context, self_value: None, label_stack: LabelStack::new() };
 
         lowerer.resolve_type_aliases();
 

--- a/lib/firefly-ast-lower/src/stmt.rs
+++ b/lib/firefly-ast-lower/src/stmt.rs
@@ -8,7 +8,7 @@ impl AstLowerer {
     pub fn lower_code_block(&mut self, code_block: &AstCodeBlock, parent: Id<Entity>, symbol_table: &mut SymbolTable) -> Id<HirCodeBlock> {
         symbol_table.push_scope();
 
-        let code_block_id = Id::<HirCodeBlock>::default();
+        let code_block_id = code_block.id;
 
         self.context.link(parent, code_block_id);
 

--- a/lib/firefly-ast-lower/src/stmt.rs
+++ b/lib/firefly-ast-lower/src/stmt.rs
@@ -1,11 +1,11 @@
 use crate::AstLowerer;
 use firefly_ast::stmt::{CodeBlock as AstCodeBlock, Stmt as AstStmt};
-use firefly_hir::{resolve::SymbolTable, stmt::{CodeBlock as HirCodeBlock, Stmt as HirStmt, StmtKind as HirStmtKind}, Entity, Id};
+use firefly_hir::{resolve::{Symbol, SymbolTable}, stmt::{CodeBlock as HirCodeBlock, Stmt as HirStmt, StmtKind as HirStmtKind}, Entity, Id};
 use firefly_span::Spanned;
 use itertools::Itertools;
 
 impl AstLowerer {
-    pub fn lower_code_block(&mut self, code_block: &AstCodeBlock, parent: Id<Entity>, symbol_table: &mut SymbolTable) {
+    pub fn lower_code_block(&mut self, code_block: &AstCodeBlock, parent: Id<Entity>, symbol_table: &mut SymbolTable) -> Id<HirCodeBlock> {
         symbol_table.push_scope();
 
         let code_block_id = Id::<HirCodeBlock>::default();
@@ -23,6 +23,8 @@ impl AstLowerer {
         });
 
         symbol_table.pop_scope();
+
+        return code_block_id;
     }
 
     pub fn lower_stmt(&mut self, stmt: &Spanned<AstStmt>, parent: Id<HirCodeBlock>, symbol_table: &mut SymbolTable) -> HirStmt {
@@ -42,7 +44,10 @@ impl AstLowerer {
                 let value = self.lower_value(&value, parent.as_base(), symbol_table);
 
                 // Create a local so we can reference the symbol
-                self.create_local(parent.as_base(), &name, &ty);
+                let local = self.create_local(parent.as_base(), &name, &ty);
+                let local_symbol = self.context.cast_id::<Symbol>(local).expect("internal compiler error: local doesn't have a symbol");
+
+                symbol_table.insert(name.name.clone(), local_symbol);
 
                 // Now return a statement
                 HirStmt::new(

--- a/lib/firefly-ast-lower/src/value.rs
+++ b/lib/firefly-ast-lower/src/value.rs
@@ -63,6 +63,17 @@ impl AstLowerer {
                 None => (HirValueKind::Unit, Ty::new(TyKind::Unit, span))
             }
 
+            AstValue::Return(return_value) => {
+                let return_value = if let Some(return_value) = return_value {
+                    self.lower_value(return_value, parent, symbol_table)
+                } else {
+                    let span = value.span;
+                    HirValue::new(HirValueKind::Unit, Ty::new(TyKind::Unit, span), span)
+                };
+
+                (HirValueKind::Return(Box::new(return_value)), Ty::new(TyKind::Never, value.span))
+            }
+
             AstValue::Error => unreachable!()
         };
 

--- a/lib/firefly-ast/src/stmt.rs
+++ b/lib/firefly-ast/src/stmt.rs
@@ -1,3 +1,4 @@
+use firefly_hir::{Id, stmt::CodeBlock as HirCodeBlock};
 use firefly_span::Spanned;
 
 use crate::{ty::Ty, value::Value, Name};
@@ -11,12 +12,14 @@ pub enum Stmt {
 
 #[derive(Debug)]
 pub struct CodeBlock {
+    pub id: Id<HirCodeBlock>,
     pub stmts: Vec<Spanned<Stmt>>,
 }
 
 impl CodeBlock {
     pub fn new(stmts: Vec<Spanned<Stmt>>) -> Self {
         Self {
+            id: Default::default(),
             stmts
         }
     }

--- a/lib/firefly-ast/src/value.rs
+++ b/lib/firefly-ast/src/value.rs
@@ -1,6 +1,6 @@
 use firefly_span::Spanned;
 
-use crate::{Name, Path};
+use crate::{stmt::CodeBlock, Name, Path};
 
 #[derive(Debug)]
 pub enum Value {
@@ -10,5 +10,19 @@ pub enum Value {
     Path(Path),
     Call(Box<Spanned<Value>>, Vec<Spanned<Value>>),
     Return(Option<Box<Spanned<Value>>>),
+    If(Box<IfStatement>),
     Error,
+}
+
+#[derive(Debug)]
+pub struct IfStatement {
+    pub condition: Spanned<Value>,
+    pub positive: CodeBlock,
+    pub negative: Option<ElseStatement>
+}
+
+#[derive(Debug)]
+pub enum ElseStatement {
+    Else(CodeBlock),
+    ElseIf(Box<IfStatement>)
 }

--- a/lib/firefly-ast/src/value.rs
+++ b/lib/firefly-ast/src/value.rs
@@ -12,6 +12,8 @@ pub enum Value {
     Return(Option<Box<Spanned<Value>>>),
     If(Box<IfStatement>),
     While(Box<WhileStatement>),
+    Break(Option<Name>),
+    Continue(Option<Name>),
     Error,
 }
 

--- a/lib/firefly-ast/src/value.rs
+++ b/lib/firefly-ast/src/value.rs
@@ -9,5 +9,6 @@ pub enum Value {
     StringLiteral(Name),
     Path(Path),
     Call(Box<Spanned<Value>>, Vec<Spanned<Value>>),
+    Return(Option<Box<Spanned<Value>>>),
     Error,
 }

--- a/lib/firefly-ast/src/value.rs
+++ b/lib/firefly-ast/src/value.rs
@@ -11,6 +11,7 @@ pub enum Value {
     Call(Box<Spanned<Value>>, Vec<Spanned<Value>>),
     Return(Option<Box<Spanned<Value>>>),
     If(Box<IfStatement>),
+    While(Box<WhileStatement>),
     Error,
 }
 
@@ -25,4 +26,11 @@ pub struct IfStatement {
 pub enum ElseStatement {
     Else(CodeBlock),
     ElseIf(Box<IfStatement>)
+}
+
+#[derive(Debug)]
+pub struct WhileStatement {
+    pub label: Option<Name>,
+    pub condition: Spanned<Value>,
+    pub body: CodeBlock,
 }

--- a/lib/firefly-hir/Cargo.toml
+++ b/lib/firefly-hir/Cargo.toml
@@ -5,5 +5,6 @@ edition = "2021"
 
 [dependencies]
 firefly-errors = { path = "../firefly-errors" }
+firefly-error-messages = { path = "../firefly-error-messages" }
 firefly-span = { path = "../firefly-span" }
 itertools = "0.13.0"

--- a/lib/firefly-hir/src/errors.rs
+++ b/lib/firefly-hir/src/errors.rs
@@ -1,3 +1,7 @@
+mod import;
+
+pub use import::*;
+
 use firefly_errors::diagnostic::Diagnostic;
 
 use crate::HirContext;

--- a/lib/firefly-hir/src/errors/import.rs
+++ b/lib/firefly-hir/src/errors/import.rs
@@ -1,0 +1,38 @@
+use firefly_error_messages::DiagnosticMessage;
+use firefly_errors::diagnostic::{Diagnostic, DiagnosticId, Level};
+
+use crate::{HirContext, Name};
+
+use super::IntoDiagnostic;
+
+pub enum ImportError {
+    MultipleImports(Name, Name),
+    NotVisible(Name),
+    NotFound(Name),
+}
+
+impl IntoDiagnostic for ImportError {
+    fn into_diagnostic(&self, _: &HirContext) -> Diagnostic {
+        match self {
+            ImportError::MultipleImports(original, import) => {
+                Diagnostic::new(Level::Error,
+                    DiagnosticMessage::Str(format!("Multiple requests for importing `{}`", original.name))
+                ).with_error_code(DiagnosticId::new("E0160"))
+                 .with_source(original.span)
+                 .with_source(import.span)
+            }
+            ImportError::NotVisible(name) => {
+                Diagnostic::new(Level::Error,
+                    DiagnosticMessage::Str(format!("Item `{}` is not visible in the current context", name.name))
+                ).with_error_code(DiagnosticId::new("E0161"))
+                 .with_source(name.span)
+            }
+            ImportError::NotFound(name) => {
+                Diagnostic::new(Level::Error,
+                    DiagnosticMessage::Str(format!("Item `{}` was not found", name.name))
+                ).with_error_code(DiagnosticId::new("E0162"))
+                 .with_source(name.span)
+            }
+        }
+    }
+}

--- a/lib/firefly-hir/src/ty/mod.rs
+++ b/lib/firefly-hir/src/ty/mod.rs
@@ -23,6 +23,8 @@ pub enum TyKind {
     String,
     Bool,
     Float,
+
+    Never,
 }
 
 /// Represents a type in the HIR.

--- a/lib/firefly-hir/src/value/mod.rs
+++ b/lib/firefly-hir/src/value/mod.rs
@@ -48,6 +48,8 @@ pub enum ValueKind {
     BuiltinFunc(&'static str),
 
     Return(Box<Value>),
+    Break(Id<CodeBlock>),
+    Continue(Id<CodeBlock>),
 
     If(Box<IfValue>),
     While(Box<WhileValue>),

--- a/lib/firefly-hir/src/value/mod.rs
+++ b/lib/firefly-hir/src/value/mod.rs
@@ -3,7 +3,7 @@ mod has_value;
 use std::fmt::Debug;
 use firefly_span::Span;
 use crate::{
-    entity::Id, func::Func, items::{Field, Global, StructDef}, stmt::{CodeBlock, Local}, ty::Ty
+    entity::Id, func::Func, items::{Field, Global, StructDef}, stmt::{CodeBlock, Local}, ty::Ty, Name
 };
 pub use has_value::*;
 
@@ -28,6 +28,13 @@ pub enum ElseValue {
 }
 
 #[derive(Debug, Clone)]
+pub struct WhileValue {
+    pub label:     Option<Name>,
+    pub condition: Value,
+    pub body:      Id<CodeBlock>,
+}
+
+#[derive(Debug, Clone)]
 pub enum ValueKind {
     Unit,
     Tuple(Vec<Value>),
@@ -43,6 +50,7 @@ pub enum ValueKind {
     Return(Box<Value>),
 
     If(Box<IfValue>),
+    While(Box<WhileValue>),
 
     Invoke(Box<Value>, Vec<Value>),
     Local(Id<Local>),

--- a/lib/firefly-hir/src/value/mod.rs
+++ b/lib/firefly-hir/src/value/mod.rs
@@ -27,6 +27,8 @@ pub enum ValueKind {
     InitFor(Id<StructDef>),
     BuiltinFunc(&'static str),
 
+    Return(Box<Value>),
+
     Invoke(Box<Value>, Vec<Value>),
     Local(Id<Local>),
     Global(Id<Global>),

--- a/lib/firefly-hir/src/value/mod.rs
+++ b/lib/firefly-hir/src/value/mod.rs
@@ -82,3 +82,9 @@ impl Debug for Value {
         self.kind.fmt(f)
     }
 }
+
+impl Default for Value {
+    fn default() -> Self {
+        Self { kind: ValueKind::Unit, ty: Ty::new_unspanned(crate::ty::TyKind::Unit), span: Default::default() }
+    }
+}

--- a/lib/firefly-hir/src/value/mod.rs
+++ b/lib/firefly-hir/src/value/mod.rs
@@ -3,7 +3,7 @@ mod has_value;
 use std::fmt::Debug;
 use firefly_span::Span;
 use crate::{
-    entity::Id, func::Func, items::{Field, Global, StructDef}, stmt::Local, ty::Ty
+    entity::Id, func::Func, items::{Field, Global, StructDef}, stmt::{CodeBlock, Local}, ty::Ty
 };
 pub use has_value::*;
 
@@ -12,6 +12,19 @@ pub enum LiteralValue {
     Integer(String),
     String(String),
     Boolean(bool),
+}
+
+#[derive(Debug, Clone)]
+pub struct IfValue {
+    pub condition: Value,
+    pub positive: Id<CodeBlock>,
+    pub negative: Option<ElseValue>
+}
+
+#[derive(Debug, Clone)]
+pub enum ElseValue {
+    Else(Id<CodeBlock>),
+    ElseIf(Box<IfValue>),
 }
 
 #[derive(Debug, Clone)]
@@ -28,6 +41,8 @@ pub enum ValueKind {
     BuiltinFunc(&'static str),
 
     Return(Box<Value>),
+
+    If(Box<IfValue>),
 
     Invoke(Box<Value>, Vec<Value>),
     Local(Id<Local>),

--- a/lib/firefly-lang/src/lib.rs
+++ b/lib/firefly-lang/src/lib.rs
@@ -1,5 +1,5 @@
 use firefly_hir::{
-    items::{Constant, Module, TypeAlias}, resolve::{Import, Symbol}, ty::{Ty, TyKind}, value::{HasValue, Value, ValueKind}, AccessComponent, BaseComponent, Component, HirContext, Id, Name, Visibility
+    items::{Constant, Module, TypeAlias}, resolve::{Import, Symbol}, ty::{Ty, TyKind}, value::{HasValue, LiteralValue, Value, ValueKind}, AccessComponent, BaseComponent, Component, HirContext, Id, Name, Visibility
 };
 use firefly_span::Span;
 
@@ -62,6 +62,9 @@ pub fn create_lang_module(context: &mut HirContext) {
     create_func("eq_str", &[TyKind::String, TyKind::String], TyKind::Bool, lang_id, context);
     create_func("neq_str", &[TyKind::String, TyKind::String], TyKind::Bool, lang_id, context);
 
+    create_literal("true", ValueKind::Literal(LiteralValue::Boolean(true)), TyKind::Bool, lang_id, context);
+    create_literal("false", ValueKind::Literal(LiteralValue::Boolean(false)), TyKind::Bool, lang_id, context);
+
     let root = context.root();
     let import_id = context.create(Import::import(Default::default(), lang_id.as_base()));
     context.link(root, import_id);
@@ -92,6 +95,34 @@ where
     context.link(parent, id);
 
     id
+}
+
+fn create_literal(
+    name: &'static str,
+    value_kind: ValueKind,
+    ty_kind: TyKind,
+    parent: Id<impl Component>,
+    context: &mut HirContext)
+{
+    let ty = Ty::new_unspanned(ty_kind);
+
+    let value = Value::new(
+        value_kind,
+        ty,
+        Span::default()
+    );
+
+    context.create_with_parent(parent, (
+        Constant::default(),
+        Symbol {
+            name: Name::internal(name),
+            visibility: Visibility::Public,
+            is_static: true,
+        },
+        HasValue {
+            value
+        }
+    ));
 }
 
 fn create_func(

--- a/lib/firefly-parser/src/error.rs
+++ b/lib/firefly-parser/src/error.rs
@@ -145,6 +145,9 @@ impl ParserErrorEnv<'_> {
             Token::StructKw => "keyword `struct`".to_string(),
 
             Token::ReturnKw => "keyword `return`".to_string(),
+			Token::BreakKw => "keyword `break`".to_string(),
+			Token::ContinueKw => "keyword `continue`".to_string(),
+
 			Token::IfKw => "keyword `if`".to_string(),
 			Token::ElseKw => "keyword `else`".to_string(),
 			Token::WhileKw => "keyword `while`".to_string(),

--- a/lib/firefly-parser/src/error.rs
+++ b/lib/firefly-parser/src/error.rs
@@ -133,20 +133,21 @@ impl ParserErrorEnv<'_> {
             Token::FilePrivateKw => "keyword `fileprivate`".to_string(),
             Token::PrivateKw => "keyword `private`".to_string(),
 
+			Token::StaticKw => "keyword `static`".to_string(),
+
             Token::ModuleKw => "keyword `module`".to_string(),
             Token::ImportKw => "keyword `import`".to_string(),
 
+			Token::AsKw => "keyword `as`".to_string(),
+
+			Token::VarKw => "keyword `var`".to_string(),
             Token::FuncKw => "keyword `func`".to_string(),
             Token::StructKw => "keyword `struct`".to_string(),
-            Token::InitKw => "keyword `init`".to_string(),
-
-            Token::VarKw => "keyword `var`".to_string(),
-
-            Token::StaticKw => "keyword `static`".to_string(),
 
             Token::ReturnKw => "keyword `return`".to_string(),
-
-            Token::AsKw => "keyword `as`".to_string(),
+			Token::IfKw => "keyword `if`".to_string(),
+			Token::ElseKw => "keyword `else`".to_string(),
+			Token::WhileKw => "keyword `while`".to_string(),
 
             // Symbols
             Token::OpenParen => "symbol `(`".to_string(),

--- a/lib/firefly-parser/src/lexer.rs
+++ b/lib/firefly-parser/src/lexer.rs
@@ -44,6 +44,9 @@ pub enum Token<'a> {
     #[token("static")] StaticKw,
 
     #[token("return")] ReturnKw,
+    #[token("break")] BreakKw,
+    #[token("continue")] ContinueKw,
+
     #[token("if")] IfKw,
     #[token("else")] ElseKw,
     #[token("while")] WhileKw,

--- a/lib/firefly-parser/src/lexer.rs
+++ b/lib/firefly-parser/src/lexer.rs
@@ -27,38 +27,26 @@ pub enum Token<'a> {
     LongStringLiteral(&'a str),
 
     // Keywords
-    #[token("public")]
-    PublicKw,
-    #[token("internal")]
-    InternalKw,
-    #[token("fileprivate")]
-    FilePrivateKw,
-    #[token("private")]
-    PrivateKw,
+    #[token("public")] PublicKw,
+    #[token("internal")] InternalKw,
+    #[token("fileprivate")] FilePrivateKw,
+    #[token("private")] PrivateKw,
 
-    #[token("module")]
-    ModuleKw,
-    #[token("import")]
-    ImportKw,
+    #[token("module")] ModuleKw,
+    #[token("import")] ImportKw,
 
-    #[token("func")]
-    FuncKw,
-    #[token("struct")]
-    StructKw,
-    #[token("init")]
-    InitKw,
+    #[token("as")] AsKw,
 
-    #[token("var")]
-    VarKw,
+    #[token("var")] VarKw,
+    #[token("func")] FuncKw,
+    #[token("struct")] StructKw,
 
-    #[token("static")]
-    StaticKw,
+    #[token("static")] StaticKw,
 
-    #[token("return")]
-    ReturnKw,
-
-    #[token("as")]
-    AsKw,
+    #[token("return")] ReturnKw,
+    #[token("if")] IfKw,
+    #[token("else")] ElseKw,
+    #[token("while")] WhileKw,
 
     // Symbols
     #[token("(")]

--- a/lib/firefly-parser/src/parser.lalrpop
+++ b/lib/firefly-parser/src/parser.lalrpop
@@ -35,20 +35,23 @@ extern {
         "fileprivate" => Token::FilePrivateKw,
         "private" => Token::PrivateKw,
 
+        "static" => Token::StaticKw,
+
         "module" => Token::ModuleKw,
         "import" => Token::ImportKw,
 
+        "as" => Token::AsKw,
+
+        "var" => Token::VarKw,
         "struct" => Token::StructKw,
         "func" => Token::FuncKw,
-        "init" => Token::InitKw,
 
         "static" => Token::StaticKw,
 
-        "var" => Token::VarKw,
-
         "return" => Token::ReturnKw,
-
-        "as" => Token::AsKw,
+        "if" => Token::IfKw,
+        "else" => Token::ElseKw,
+        "while" => Token::WhileKw,
 
         "integer" => Token::IntegerLiteral(<&'source str>),
         "string" => Token::StringLiteral(<&'source str>),
@@ -190,14 +193,29 @@ CodeBlock: CodeBlock = {
 // Values
 Value = { Spanned<UnspannedValue> }
 UnspannedValue: Value = {
+    FlowExpr => <>
+}
+
+FlowExpr: Value = {
+    TrailingExpr => <>,
+    "return" <value: Value?> => Value::Return(value.map(Box::new))
+}
+
+TrailingExpr: Value = {
+    AtomExpr => <>,
+    <func: Spanned<AtomExpr>> "(" <args: CommaList<Value>> ")" => Value::Call(Box::new(func), args),
+}
+
+AtomExpr: Value = {
+    LiteralValue => <>,
     "(" <items: CommaList<Value>> ")" => Value::Tuple(items),
+    <Path> => Value::Path(<>),
+}
+
+LiteralValue: Value = {
     Spanned<"integer"> => Value::IntegerLiteral(Spanned::new(<>.item.into(), <>.span)),
     Spanned<"string"> => Value::StringLiteral(Spanned::new(<>.item.into(), <>.span)),
     Spanned<"long_string"> => Value::StringLiteral(Spanned::new(<>.item.into(), <>.span)),
-    <func: Value> "(" <args: CommaList<Value>> ")" => Value::Call(Box::new(func), args),
-    <Path> => Value::Path(<>),
-
-    ExpectValue => Value::Error,
 }
 
 // Types

--- a/lib/firefly-parser/src/parser.lalrpop
+++ b/lib/firefly-parser/src/parser.lalrpop
@@ -2,7 +2,7 @@ use firefly_ast::{
     Visibility,
     Path, PathSegment,
     ty::Ty,
-    value::{Value, IfStatement, ElseStatement},
+    value::{Value, IfStatement, ElseStatement, WhileStatement},
     stmt::{Stmt, CodeBlock},
     func::{Func, FuncParam},
     item::Item,
@@ -199,6 +199,7 @@ UnspannedValue: Value = {
 FlowExpr: Value = {
     TrailingExpr => <>,
     IfStatement => Value::If(Box::new(<>)),
+    WhileStatement => Value::While(Box::new(<>)),
     "return" <value: Value?> => Value::Return(value.map(Box::new))
 }
 
@@ -224,6 +225,19 @@ IfStatement: IfStatement = {
         condition,
         positive,
         negative,
+    }
+}
+
+WhileStatement: WhileStatement = {
+    "while" <condition: Value> <body: CodeBlock> => WhileStatement {
+        label: None,
+        condition,
+        body
+    },
+    <label: Name> ":" "while" <condition: Value> <body: CodeBlock> => WhileStatement {
+        label: Some(label),
+        condition,
+        body
     }
 }
 

--- a/lib/firefly-parser/src/parser.lalrpop
+++ b/lib/firefly-parser/src/parser.lalrpop
@@ -49,6 +49,9 @@ extern {
         "static" => Token::StaticKw,
 
         "return" => Token::ReturnKw,
+        "break" => Token::BreakKw,
+        "continue" => Token::ContinueKw,
+
         "if" => Token::IfKw,
         "else" => Token::ElseKw,
         "while" => Token::WhileKw,
@@ -212,6 +215,8 @@ AtomExpr: Value = {
     LiteralValue => <>,
     "(" <items: CommaList<Value>> ")" => Value::Tuple(items),
     <Path> => Value::Path(<>),
+    BreakValue => <>,
+    ContinueValue => <>,
 }
 
 LiteralValue: Value = {
@@ -244,6 +249,14 @@ WhileStatement: WhileStatement = {
 ElseStatement: ElseStatement = {
     "else" <negative: CodeBlock> => ElseStatement::Else(negative),
     "else" <negative: IfStatement> => ElseStatement::ElseIf(Box::new(negative)),
+}
+
+BreakValue: Value = {
+    "break" <label: Name?> => Value::Break(label)
+}
+
+ContinueValue: Value = {
+    "continue" <label: Name?> => Value::Continue(label)
 }
 
 // Types

--- a/lib/firefly-parser/src/parser.lalrpop
+++ b/lib/firefly-parser/src/parser.lalrpop
@@ -2,7 +2,7 @@ use firefly_ast::{
     Visibility,
     Path, PathSegment,
     ty::Ty,
-    value::Value,
+    value::{Value, IfStatement, ElseStatement},
     stmt::{Stmt, CodeBlock},
     func::{Func, FuncParam},
     item::Item,
@@ -198,6 +198,7 @@ UnspannedValue: Value = {
 
 FlowExpr: Value = {
     TrailingExpr => <>,
+    IfStatement => Value::If(Box::new(<>)),
     "return" <value: Value?> => Value::Return(value.map(Box::new))
 }
 
@@ -216,6 +217,19 @@ LiteralValue: Value = {
     Spanned<"integer"> => Value::IntegerLiteral(Spanned::new(<>.item.into(), <>.span)),
     Spanned<"string"> => Value::StringLiteral(Spanned::new(<>.item.into(), <>.span)),
     Spanned<"long_string"> => Value::StringLiteral(Spanned::new(<>.item.into(), <>.span)),
+}
+
+IfStatement: IfStatement = {
+    "if" <condition: Value> <positive: CodeBlock> <negative: ElseStatement?> => IfStatement {
+        condition,
+        positive,
+        negative,
+    }
+}
+
+ElseStatement: ElseStatement = {
+    "else" <negative: CodeBlock> => ElseStatement::Else(negative),
+    "else" <negative: IfStatement> => ElseStatement::ElseIf(Box::new(negative)),
 }
 
 // Types

--- a/tests/Calling/Instance.fly
+++ b/tests/Calling/Instance.fly
@@ -6,7 +6,7 @@ struct Package {
     var version: string
 
     func format() -> string {
-        concat(
+        return concat(
             self.name,
             concat (
                 " ",

--- a/tests/Flow/Break.fly
+++ b/tests/Flow/Break.fly
@@ -36,4 +36,6 @@ func main() {
             break outer;
         };
     };
+
+    break outer;
 }

--- a/tests/Flow/Break.fly
+++ b/tests/Flow/Break.fly
@@ -1,0 +1,39 @@
+module Test.WhileLoop
+
+func main() {
+    var i: int = 0;
+
+    // Test outside a loop
+    break;
+
+    // Test normal
+    while leq_int(i, 10) {
+        break;
+    };
+
+    // Test nested
+    while leq_int(i, 10) {
+        while leq_int(i, 10) {
+            break;
+        };
+    };
+
+    // Test labeled
+    outer: while leq_int(i, 10) {
+        break;
+    };
+
+    // Test nested labeled
+    outer: while leq_int(i, 10) {
+        inner: while leq_int(i, 10) {
+            break outer;
+        };
+    };
+
+    // Test shadowing
+    outer: while leq_int(i, 10) {
+        outer: while leq_int(i, 10) {
+            break outer;
+        };
+    };
+}

--- a/tests/Flow/Factorial.fly
+++ b/tests/Flow/Factorial.fly
@@ -1,0 +1,9 @@
+module Test.Factorial;
+
+func factorial(n: int) -> int {
+    if leq_int(n, 1) {
+        return 1;
+    };
+
+    return mul(n, factorial(sub(n, 1)));
+}

--- a/tests/Flow/Fibonacci.fly
+++ b/tests/Flow/Fibonacci.fly
@@ -1,0 +1,19 @@
+module Test.Fibonacci;
+
+func fibonacci(n: int) -> int {
+    var i: int = 1;
+
+    var n1 = 1
+    var n2 = 1
+
+    while lessThan(i, n) {
+        var n3 = add(n1, n2);
+
+        n1 = n2;
+        n2 = n3;
+
+        i = add(i, 1);
+    }
+
+    return n2;
+}

--- a/tests/Flow/Shadow.fly
+++ b/tests/Flow/Shadow.fly
@@ -1,0 +1,23 @@
+module Test.Shadow
+
+func main(should_run: bool) {
+    var shadow: int = 0;
+
+    if should_run {
+        var shadow: string = "Hello, World";
+        print(shadow);
+    };
+
+    print(format_int(shadow));
+
+    var shadow: string = "Hello, World";
+    print(shadow);
+}
+
+func in_block(should_run: bool) {
+    if should_run {
+        var inner: string = "Hello, World";
+    };
+
+    print(inner);
+}

--- a/tests/Flow/WhileLoop.fly
+++ b/tests/Flow/WhileLoop.fly
@@ -1,0 +1,12 @@
+module Test.WhileLoop
+
+func main() {
+    var i: int = 0;
+
+    while leq_int(i, 10) {
+
+    };
+
+    outer: while leq_int(i, 10) {
+    };
+}

--- a/todo.md
+++ b/todo.md
@@ -16,7 +16,7 @@
 - [x] Add function calls
 - [x] Add system functions
 - [x] Methods
-- [ ] Add control flow
+- [x] Add control flow
 
 # Testing framework
 

--- a/todo.md
+++ b/todo.md
@@ -15,7 +15,7 @@
 - [x] Add members
 - [x] Add function calls
 - [x] Add system functions
-- [ ] Methods
+- [x] Methods
 - [ ] Add control flow
 
 # Testing framework


### PR DESCRIPTION
# Control Flow

## If

Checks a condition, running one block of code if it is true and another if it is false.

### Syntax

```firefly
if condition {
    // run this code
}
else if other_condition {
    // run this code
}
else {
    // run this code
}
```

### Semantics

If the condition isn't a boolean, throw an error
After the if statement, an else statement can run a code block or another if statement
The first if statement which's condition is true runs
An if statement is a value with the type `()`


## While

Runs a block of code while a condition is true. If the condition is initially false, never runs the code.

### Syntax

```firefly
while condition {

}

label: while condition {

}
```

### Semantics

- Throws an error if condition is not a boolean
- Runs the code while the condition is true
- Evaluates the condition on each run-through
- Able to be exited early with the break keyword
- Using a label allows a specific loop to be exited
- Labels are available within their block
- Labels shadow other, outside labels with the same name

## Break

A break statement exits from a loop. It can specify which loop to exit, or else it will exit the innermost loop.

### Syntax

```firefly
break
break label
```

### Semantics

- If it isn't in a loop, an error is thrown
- If the label doesn't exist, an error is thrown
- A break value has the never type

## Break

A continue statement moves to the next iteration of a loop. It can specify which loop to continue, or else it will continue the innermost loop.

### Syntax

```firefly
continue
continue label
```

### Semantics

- If it isn't in a loop, an error is thrown
- If the label doesn't exist, an error is thrown
- A continue value has the never type

## Return

Returns from the function early, possibly returning a value.

### Syntax

```firefly
return
return value
```

### Semantics

If the value returned is omitted, it will be assumed to be the unit tuple `()`.
The type of the value returned must match the return type of the function it is called in
Outside of a function, a return statement can't be used