### PR TITLE
Feature/argument labels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
  "firefly-mangle",
  "firefly-parser",
  "firefly-span",
- "itertools 0.13.0",
+ "itertools 0.14.0",
 ]
 
 [[package]]
@@ -478,6 +478,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ firefly-lang = { path = "lib/firefly-lang" }
 firefly-errors = { path = "lib/firefly-errors" }
 firefly-driver = { path = "lib/firefly-driver" }
 firefly-mangle = { path = "lib/firefly-mangle" }
-itertools = "0.13.0"
+itertools = "0.14.0"
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -10,18 +10,18 @@ In its current state, firefly can be used for basic mathematical functions.
 module Fibonacci
 
 func fibonacci(n: int) -> int {
-    var i: int = 1;
+    var i = 1;
 
-    var n1: int = 1;
-    var n2: int = 1;
+    var n1 = 1;
+    var n2 = 1;
 
-    while lt_int(i, n) {
-        var n3: int = add(n1, n2);
+    while i < n {
+        var n3 = n1 + n2;
 
         n1 = n2;
         n2 = n3;
 
-        i = add(i, 1);
+        i = i + 1;
     }
 
     return n2;
@@ -30,4 +30,4 @@ func fibonacci(n: int) -> int {
 
 ## Running
 
-To run firefly, use the CLI with the list of files to compile as arguments. The `--print-hir` flag dumps the hir tree to the console.
+To run firefly, use the CLI with the list of files to compile as arguments. Your program will run in an interpreter. The `--print-hir` flag dumps the hir tree to the console, and `--print-mir` dumps mir.

--- a/docs/features/Errors.md
+++ b/docs/features/Errors.md
@@ -1,20 +1,22 @@
 E01xx: Symbol Errors
 
 E0101: Symbol not found
-    A symbol was not found in the namespace
+A symbol was not found in the namespace
 E0102: Symbol not visible
-    A symbol is not visible
+A symbol is not visible
 E0103: Symbol not found in
-    Has no member
+Has no member
 E0104: Symbol not a type
-    Tried to use value as a type
+Tried to use value as a type
 E0105: Symbol not a value
-    Tried to use type as a value
+Tried to use type as a value
 
 E0120: Value doesn't have children
-    Tried to get a child of a value without children
+Tried to get a child of a value without children
 E0121: Member not found
-E0122:
+E0122: Member is not a value
+E0123: No member found matching predicate
+E0124: Ambiguous member found matching predicate
 
 E020x: String Errors
 
@@ -32,15 +34,15 @@ E0152: No Module Found
 E016x: Import errors
 
 E0160: Multiple definitions found for
-E0161: Item `` is not visible in the current context
-E0162: Item `` is not found
+E0161: Item `is not visible in the current context
+E0162: Item` is not found
 
 E030x: Break/Continue errors
 
 E0301: Break outside of loop
-E0302: Can't find loop with label `` for break
+E0302: Can't find loop with label `for break
 E0303: Continue outside of loop
-E0304: Can't find loop with label `` for continue
+E0304: Can't find loop with label` for continue
 
 E0310: Value isn't mutable
 

--- a/lib/core/Iterator.fly
+++ b/lib/core/Iterator.fly
@@ -1,0 +1,10 @@
+protocol Iterator {
+  associatedtype Item;
+  associatedtype Error = !;
+
+  func next() -> Item? throws Error;
+}
+
+protocol ExactSizeIterator {
+  func size() -> Int;
+}

--- a/lib/core/List.fly
+++ b/lib/core/List.fly
@@ -1,8 +1,140 @@
 struct List[T] {
-    var count: UInt
-    var isEmpty: Bool
+    private var inner: RawPointer[T]
+    private var length: UInt
+    private var capacity: UInt   
 
-    func append(item: T)
-    func prepend(item: T)
-    func insert(item: T, at index: UInt)
+    var count: UInt {
+        get { length }
+    }
+    var isEmpty: Bool {
+        get { length == 0 }
+    }
+
+    init() {
+        inner = nil;
+        length = 0;
+        capacity = 0;
+    }
+
+    init(withCapacity capacity: UInt) {
+        inner = RawPointer.reserve(capacity: capacity)
+        length = 0;
+        self.capacity = capacity;
+    }
+
+    /// Internal function that ensures the list
+    /// has enough capacity for all the items
+    private func reserveCapacity(capacity: UInt) {
+        if capacity <= self.capacity {
+            return;
+        }
+
+        // Reserve the smallest power of 2 bigger than capacity
+        let newCapacity = smallestPowerOf2Over(capacity);
+
+        let newPointer = RawPointer.reserve(capacity: newCapacity);
+        newPointer.copyFrom(self.inner, length: self.count);
+        self.inner.deallocate();
+
+        self.inner = newPointer;
+        self.capacity = newCapacity;
+    }
+
+    /// Internal function that ensures the list
+    /// Doesn't take too much space
+    private func shrinkTo(newCapacity: UInt) throws ListError {
+        if capacity < self.count {
+            throw .OutOfRange
+        }
+
+        let newPointer = RawPointer.reserve(capacity: newCapacity);
+        newPointer.copyFrom(self.inner, length: self.count);
+        self.inner.deallocate();
+
+        self.inner = newPointer;
+        self.capacity = newCapacity;
+    }
+
+    /// Add a new item to the end of the list
+    func append(item: T) {
+        self.reserveCapacity(self.count + 1);
+
+        self.inner.set(self.count, item);
+
+        self.count += 1;
+    }
+
+    /// Add a new item to the end of the list
+    func prepend(item: T) {
+        self.insert(item, at: 0)
+    }
+
+    /// Insert an item at an arbitrary index
+    func insert(item: T, at index: UInt) throws ListError {
+        if index > self.count {
+            throw .OutOfRange
+        }
+
+        self.reserveCapacity(self.count + 1);
+
+        for i in (index..<self.count).reversed() {
+            self.inner.copyIndex(i, to: i + 1);
+        }
+    }
+
+    /// Pops an item from the end of the list,
+    /// throwing an error if it is empty
+    func pop() -> T? {
+        if self.isEmpty {
+            return nil
+        }
+
+        self.count -= 1;
+
+        return self.inner.get(self.count);
+    }
+
+    /// Pops an item at the beginning of the list
+    func popStart() -> T? {
+        if self.isEmpty {
+            return nil;
+        }
+
+        try! self.take(at: 0)
+    }
+
+    /// Take an item from the list, removing and returning it
+    func take(at index: Int) -> T throws ListError {
+        guard index < self.count else {
+            throw .OutOfRange
+        }
+
+        self.count -= 1;
+
+        let item = self.inner.get(index);
+
+        for i in index..<self.count {
+            self.inner.copyIndex(i + 1, to: i)
+        }
+
+        return item;
+    }
+
+    /// Shrink to the minimum size required by the list's items
+    func shrink_fit() {
+        try! self.shrinkTo(self.count)
+    }
+
+    /// Swaps an element into a list, returning the value that was already there
+    func swap(element: T, to index: UInt) -> T throws ListError {
+        if index >= self.count {
+            throw .OutOfRange
+        }
+
+        let item = self.inner.get(index);
+
+        self.inner.set(index, element);
+
+        return item;
+    }
 }

--- a/lib/firefly-ast-lower/src/errors/symbol.rs
+++ b/lib/firefly-ast-lower/src/errors/symbol.rs
@@ -18,7 +18,7 @@ pub enum SymbolError {
 }
 
 impl IntoDiagnostic for SymbolError {
-    fn into_diagnostic(&self, context: &HirContext) -> firefly_errors::diagnostic::Diagnostic {
+    fn into_diagnostic(&self, _context: &HirContext) -> firefly_errors::diagnostic::Diagnostic {
         match self {
             SymbolError::NotFound(name) => Diagnostic::new(
                 Level::Error,

--- a/lib/firefly-ast-lower/src/errors/symbol.rs
+++ b/lib/firefly-ast-lower/src/errors/symbol.rs
@@ -15,6 +15,9 @@ pub enum SymbolError {
     NoMembersOf(Value),
     NoMemberOn(Name, Value),
     MemberNotAValue(Name, Span),
+
+    NoMatchingSymbol(String, Vec<Span>),
+    AmbiguousSymbol(String, Vec<Span>),
 }
 
 impl IntoDiagnostic for SymbolError {
@@ -76,6 +79,18 @@ impl IntoDiagnostic for SymbolError {
             .with_error_code(DiagnosticId::new("E0122"))
             .with_source(name.span)
             .with_source(*decl),
+            SymbolError::NoMatchingSymbol(predicate, spans) => Diagnostic::new(
+                Level::Error,
+                DiagnosticMessage::Str(format!("no option found matching {}", predicate)),
+            )
+            .with_error_code(DiagnosticId::new("E0123"))
+            .with_sources(spans),
+            SymbolError::AmbiguousSymbol(predicate, spans) => Diagnostic::new(
+                Level::Error,
+                DiagnosticMessage::Str(format!("ambiguous option found matching {}", predicate)),
+            )
+            .with_error_code(DiagnosticId::new("E0124"))
+            .with_sources(spans),
         }
     }
 }

--- a/lib/firefly-ast-lower/src/resolve_condition.rs
+++ b/lib/firefly-ast-lower/src/resolve_condition.rs
@@ -1,0 +1,57 @@
+use firefly_hir::{func::Callable, resolve::Symbol, HirContext, Id};
+use firefly_span::Spanned;
+use itertools::Itertools;
+
+pub trait ResolveCondition {
+    fn matches(&self, symbol: Id<Symbol>, context: &HirContext) -> bool;
+
+    fn format_for_error(&self) -> String;
+}
+
+pub struct CallableResolveCondition {
+    pub labels: Vec<Option<Spanned<String>>>,
+}
+
+impl ResolveCondition for CallableResolveCondition {
+    fn matches(&self, id: Id<Symbol>, context: &HirContext) -> bool {
+        let Some(symbol) = context.try_get::<Callable>(id) else {
+            return false;
+        };
+
+        if symbol.labels.len() != self.labels.len() {
+            return false;
+        }
+
+        for (label, expected_label) in symbol.labels.iter().zip(self.labels.iter()) {
+            match (label, expected_label) {
+                (Some(label), Some(expected_label)) if label.name == expected_label.item => {}
+                (None, None) => {}
+                _ => return false,
+            }
+        }
+
+        return true;
+    }
+
+    fn format_for_error(&self) -> String {
+        return format!(
+            "func ({})",
+            self.labels
+                .iter()
+                .map(|label| label.as_ref().map_or("", |label| label.item.as_str()))
+                .join(", ")
+        );
+    }
+}
+
+pub struct UnconditionalResolveCondition;
+
+impl ResolveCondition for UnconditionalResolveCondition {
+    fn matches(&self, _: Id<Symbol>, _: &HirContext) -> bool {
+        true
+    }
+
+    fn format_for_error(&self) -> String {
+        unreachable!()
+    }
+}

--- a/lib/firefly-ast-lower/src/resolve_condition.rs
+++ b/lib/firefly-ast-lower/src/resolve_condition.rs
@@ -8,6 +8,7 @@ pub trait ResolveCondition {
     fn format_for_error(&self) -> String;
 }
 
+#[derive(Debug, Clone)]
 pub struct CallableResolveCondition {
     pub labels: Vec<Option<Spanned<String>>>,
 }
@@ -44,6 +45,7 @@ impl ResolveCondition for CallableResolveCondition {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct UnconditionalResolveCondition;
 
 impl ResolveCondition for UnconditionalResolveCondition {
@@ -52,6 +54,6 @@ impl ResolveCondition for UnconditionalResolveCondition {
     }
 
     fn format_for_error(&self) -> String {
-        unreachable!()
+        return "blank".into();
     }
 }

--- a/lib/firefly-ast-lower/src/value.rs
+++ b/lib/firefly-ast-lower/src/value.rs
@@ -348,10 +348,10 @@ impl AstLowerer {
     ) -> HirValue {
         let span = value.span;
 
+        let condition = CallableResolveCondition { labels };
+
         match &value.item {
             AstValue::Path(path) => {
-                let condition = CallableResolveCondition { labels };
-
                 match self.resolve_value_with(path, parent, symbol_table, condition) {
                     Some(value) => return value,
                     None => {
@@ -369,7 +369,7 @@ impl AstLowerer {
                     self.lower_value(parent_val, parent, symbol_table, context.reset());
 
                 if let Some(member) =
-                    self.resolve_instance_member(parent_val, member.clone(), parent)
+                    self.resolve_instance_member_with(parent_val, member.clone(), parent, condition)
                 {
                     return member;
                 }

--- a/lib/firefly-ast-lower/src/value.rs
+++ b/lib/firefly-ast-lower/src/value.rs
@@ -97,7 +97,7 @@ impl AstLowerer {
 
                 let args = args
                     .iter()
-                    .map(|arg| self.lower_value(arg, parent, symbol_table, context.reset()))
+                    .map(|arg| self.lower_value(&arg.value, parent, symbol_table, context.reset()))
                     .collect_vec();
 
                 let invoke = HirValueKind::Invoke(Box::new(function_value), args);

--- a/lib/firefly-ast/src/func.rs
+++ b/lib/firefly-ast/src/func.rs
@@ -5,14 +5,15 @@ use crate::{stmt::CodeBlock, ty::Ty, Name, Visibility};
 
 #[derive(Debug)]
 pub struct FuncParam {
+    pub label: Option<Name>,
     pub name: Name,
     pub ty: Spanned<Ty>,
 }
 
 #[derive(Debug)]
 pub struct FuncSignature {
-    pub params:     Vec<Spanned<FuncParam>>,
-    pub return_ty:  Option<Spanned<Ty>>,
+    pub params: Vec<Spanned<FuncParam>>,
+    pub return_ty: Option<Spanned<Ty>>,
 }
 
 #[derive(Debug)]
@@ -46,7 +47,7 @@ impl Func {
 }
 
 impl FuncParam {
-    pub fn new(name: Name, ty: Spanned<Ty>) -> Self {
-        Self { name, ty }
+    pub fn new(label: Option<Name>, name: Name, ty: Spanned<Ty>) -> Self {
+        Self { label, name, ty }
     }
 }

--- a/lib/firefly-ast/src/value.rs
+++ b/lib/firefly-ast/src/value.rs
@@ -13,7 +13,7 @@ pub enum Value {
     FloatLiteral(Name),
     StringLiteral(Name),
     Path(Path),
-    Call(Box<Spanned<Value>>, Vec<Spanned<Value>>),
+    Call(Box<Spanned<Value>>, Vec<CallArg>),
     Return(Option<Box<Spanned<Value>>>),
     If(Box<IfStatement>),
     While(Box<WhileStatement>),
@@ -25,6 +25,12 @@ pub enum Value {
     Prefix(PrefixOperator, Box<Spanned<Value>>),
     Infix(Box<Spanned<Value>>, InfixOperator, Box<Spanned<Value>>),
     Error,
+}
+
+#[derive(Debug, Clone)]
+pub struct CallArg {
+    pub label: Option<Name>,
+    pub value: Spanned<Value>,
 }
 
 #[derive(Debug, Clone)]

--- a/lib/firefly-errors/src/diagnostic.rs
+++ b/lib/firefly-errors/src/diagnostic.rs
@@ -5,138 +5,139 @@ use firefly_span::Span;
 use termcolor::Color;
 
 pub struct DiagnosticId {
-	error: String,
+    error: String,
 }
 
 pub enum Level {
-	Hint,
-	Warning,
-	Info,
-	Error,
-	Fatal,
+    Hint,
+    Warning,
+    Info,
+    Error,
+    Fatal,
 }
 
 pub struct Diagnostic {
-	///
-	/// The seriousness of this diagnostic
-	///
-	pub level: Level,
+    ///
+    /// The seriousness of this diagnostic
+    ///
+    pub level: Level,
 
-	///
-	///
-	///
-	pub message: DiagnosticMessage,
+    ///
+    ///
+    ///
+    pub message: DiagnosticMessage,
 
-	///
-	/// The error code of this diagnostic
-	///
-	pub code: Option<DiagnosticId>,
+    ///
+    /// The error code of this diagnostic
+    ///
+    pub code: Option<DiagnosticId>,
 
-	///
-	/// The location that threw this diagnostic
-	/// Very useful for debugging
-	///
-	pub source_location: DiagnosticLocation,
+    ///
+    /// The location that threw this diagnostic
+    /// Very useful for debugging
+    ///
+    pub source_location: DiagnosticLocation,
 
-	///
-	/// todo: Very temporary
-	///
-	pub source: Vec<Span>,
+    ///
+    /// todo: Very temporary
+    ///
+    pub source: Vec<Span>,
 }
 
 pub struct DiagnosticLocation {
-	pub file: &'static str,
-	pub line: u32,
-	pub col: u32,
+    pub file: &'static str,
+    pub line: u32,
+    pub col: u32,
 }
 
 impl DiagnosticLocation {
-	#[track_caller]
-	pub fn caller() -> Self {
-		let location = Location::caller();
-		DiagnosticLocation {
-			file: location.file(),
-			line: location.line(),
-			col: location.column(),
-		}
-	}
+    #[track_caller]
+    pub fn caller() -> Self {
+        let location = Location::caller();
+        DiagnosticLocation {
+            file: location.file(),
+            line: location.line(),
+            col: location.column(),
+        }
+    }
 
-	fn new(location: &'static Location) -> Self {
-		DiagnosticLocation {
-			file: location.file(),
-			line: location.line(),
-			col: location.column(),
-		}
-	}
+    fn new(location: &'static Location) -> Self {
+        DiagnosticLocation {
+            file: location.file(),
+            line: location.line(),
+            col: location.column(),
+        }
+    }
 }
 
 impl Diagnostic {
-	#[track_caller]
-	pub fn new(level: Level, message: DiagnosticMessage) -> Self {
-		Diagnostic {
-			level,
-			message,
-			code: None,
-			source_location: DiagnosticLocation::new(Location::caller()),
-			source: Vec::new(),
-		}
-	}
+    #[track_caller]
+    pub fn new(level: Level, message: DiagnosticMessage) -> Self {
+        Diagnostic {
+            level,
+            message,
+            code: None,
+            source_location: DiagnosticLocation::new(Location::caller()),
+            source: Vec::new(),
+        }
+    }
 
-	pub fn with_error_code(mut self, code: DiagnosticId) -> Self {
-		self.code = Some(code);
-		self
-	}
+    pub fn with_error_code(mut self, code: DiagnosticId) -> Self {
+        self.code = Some(code);
+        self
+    }
 
-	pub fn with_source(mut self, source: Span) -> Self {
-		self.source.push(source);
-		self
-	}
+    pub fn with_source(mut self, source: Span) -> Self {
+        self.source.push(source);
+        self
+    }
+
+    pub fn with_sources(mut self, sources: &Vec<Span>) -> Self {
+        self.source.extend(sources);
+        self
+    }
 }
 
 impl DiagnosticId {
-	pub fn new(code: impl ToString) -> DiagnosticId {
-		DiagnosticId {
-			error: code.to_string(),
-		}
-	}
+    pub fn new(code: impl ToString) -> DiagnosticId {
+        DiagnosticId {
+            error: code.to_string(),
+        }
+    }
 }
 
 impl Display for DiagnosticLocation {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		write!(
-			f,
-			"{}:{}:{}",
-			self.file, self.line, self.col
-		)
-	}
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}:{}", self.file, self.line, self.col)
+    }
 }
 
 impl Level {
-	pub fn color(&self) -> Color {
-		match self {
-			Level::Hint => Color::Green,
-			Level::Warning => Color::Yellow,
-			Level::Info => Color::Blue,
-			Level::Error => Color::Red,
-			Level::Fatal => Color::Magenta,
-		}
-	}
+    pub fn color(&self) -> Color {
+        match self {
+            Level::Hint => Color::Green,
+            Level::Warning => Color::Yellow,
+            Level::Info => Color::Blue,
+            Level::Error => Color::Red,
+            Level::Fatal => Color::Magenta,
+        }
+    }
 }
 
 impl Display for Level {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		match self {
-			Level::Hint => write!(f, "hint"),
-			Level::Warning => write!(f, "warning"),
-			Level::Info => write!(f, "info"),
-			Level::Error => write!(f, "error"),
-			Level::Fatal => write!(f, "fatal"),
-		}
-	}
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Level::Hint => write!(f, "hint"),
+            Level::Warning => write!(f, "warning"),
+            Level::Info => write!(f, "info"),
+            Level::Error => write!(f, "error"),
+            Level::Fatal => write!(f, "fatal"),
+        }
+    }
 }
 
 impl Display for DiagnosticId {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		write!(f, "{}", self.error)
-	}
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.error)
+    }
 }

--- a/lib/firefly-hir/src/func/signature.rs
+++ b/lib/firefly-hir/src/func/signature.rs
@@ -1,6 +1,10 @@
 use itertools::Itertools;
 
-use crate::{stmt::Local, ty::{Ty, TyKind}, Id, Name};
+use crate::{
+    stmt::Local,
+    ty::{Ty, TyKind},
+    Id, Name,
+};
 
 /// Marks a symbol as callable and provides a signature
 /// for calling the symbol
@@ -20,13 +24,9 @@ pub struct FuncParam {
 
 component!(callables: Callable);
 
-
 impl Callable {
     pub fn ty(&self) -> Ty {
-        let params = self.params.iter()
-                                .map(|p| &p.ty)
-                                .cloned()
-                                .collect_vec();
+        let params = self.params.iter().map(|p| &p.ty).cloned().collect_vec();
         let kind = TyKind::Func(params, Box::new(self.return_ty.clone()));
 
         Ty::new_unspanned(kind)

--- a/lib/firefly-hir/src/func/signature.rs
+++ b/lib/firefly-hir/src/func/signature.rs
@@ -10,6 +10,7 @@ use crate::{
 /// for calling the symbol
 #[derive(Debug, Clone)]
 pub struct Callable {
+    pub labels: Vec<Option<Name>>,
     pub params: Vec<FuncParam>,
     pub return_ty: Ty,
     pub receiver: Option<Ty>,

--- a/lib/firefly-hir/src/resolve/collection.rs
+++ b/lib/firefly-hir/src/resolve/collection.rs
@@ -1,4 +1,4 @@
-use crate::{ty::HasType, HirContext, Id};
+use crate::Id;
 
 use super::Symbol;
 
@@ -25,6 +25,9 @@ impl SymbolCollection {
     }
 
     pub fn add(&mut self, symbol: Id<Symbol>) {
+        if self.symbols.contains(&symbol) {
+            return;
+        }
         self.symbols.push(symbol);
     }
 

--- a/lib/firefly-hir/src/resolve/collection.rs
+++ b/lib/firefly-hir/src/resolve/collection.rs
@@ -1,0 +1,52 @@
+use crate::{ty::HasType, HirContext, Id};
+
+use super::Symbol;
+
+#[derive(Debug, Clone)]
+pub struct SymbolCollection {
+    pub symbols: Vec<Id<Symbol>>,
+}
+
+impl Default for SymbolCollection {
+    fn default() -> Self {
+        Self {
+            symbols: Vec::new(),
+        }
+    }
+}
+
+impl SymbolCollection {
+    pub fn new(symbols: Vec<Id<Symbol>>) -> Self {
+        Self { symbols }
+    }
+
+    pub fn new_single(symbol: Id<Symbol>) -> Self {
+        Self::new(vec![symbol])
+    }
+
+    pub fn add(&mut self, symbol: Id<Symbol>) {
+        self.symbols.push(symbol);
+    }
+
+    pub fn single(&self) -> Option<Id<Symbol>> {
+        if self.symbols.len() > 1 {
+            return None;
+        }
+
+        self.symbols.get(0).copied()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.symbols.is_empty()
+    }
+
+    pub fn symbols_matching(&self, predicate: impl Fn(Id<Symbol>) -> bool) -> Self {
+        Self::new(
+            self.symbols
+                .iter()
+                .filter(|&&id| predicate(id))
+                .copied()
+                .collect(),
+        )
+    }
+}

--- a/lib/firefly-hir/src/resolve/mod.rs
+++ b/lib/firefly-hir/src/resolve/mod.rs
@@ -1,13 +1,15 @@
+mod collection;
+mod import;
 mod member_table;
 mod namespace;
 mod symbol;
 mod symbol_table;
-mod import;
 mod visible;
 
+pub use collection::*;
+pub use import::*;
 pub use member_table::*;
 pub use namespace::*;
 pub use symbol::*;
 pub use symbol_table::*;
-pub use import::*;
 pub use visible::*;

--- a/lib/firefly-interpret/src/lib.rs
+++ b/lib/firefly-interpret/src/lib.rs
@@ -147,7 +147,7 @@ impl<'a> ExecutionEngine<'a> {
                         let (InnerValue::Integer(left), InnerValue::Integer(right)) =
                             (left.as_ref(), right.as_ref())
                         else {
-                            panic!("{op}");
+                            panic!("{op} {left:?} {right:?}");
                         };
 
                         return self.eval_int_op(*op, *left, *right);

--- a/lib/firefly-interpret/src/stack_frame.rs
+++ b/lib/firefly-interpret/src/stack_frame.rs
@@ -1,13 +1,13 @@
 use super::value::{InnerValue, Value};
 
 pub struct StackFrame {
-    frame: Vec<Value>
+    frame: Vec<Value>,
 }
 
 impl StackFrame {
     pub fn new(size: usize, params: Vec<Value>) -> Self {
         assert!(size >= params.len());
-        
+
         let param_len = params.len();
 
         let mut frame = params;
@@ -19,11 +19,16 @@ impl StackFrame {
         Self { frame }
     }
 
+    #[allow(dead_code)]
     pub fn get_value(&self, n: usize) -> &Value {
-        self.frame.get(n).expect("internal error: stack frame access out of bounds")
+        self.frame
+            .get(n)
+            .expect("internal error: stack frame access out of bounds")
     }
 
     pub fn get_value_mut(&mut self, n: usize) -> &mut Value {
-        self.frame.get_mut(n).expect("internal error: stack frame access out of bounds")
+        self.frame
+            .get_mut(n)
+            .expect("internal error: stack frame access out of bounds")
     }
 }

--- a/lib/firefly-parser/src/parser.lalrpop
+++ b/lib/firefly-parser/src/parser.lalrpop
@@ -2,7 +2,7 @@ use firefly_ast::{
     Visibility,
     Path, PathSegment,
     ty::Ty,
-    value::{Value, IfStatement, ElseStatement, WhileStatement},
+    value::{Value, IfStatement, ElseStatement, WhileStatement, CallArg},
     stmt::{Stmt, CodeBlock},
     func::{Func, FuncParam},
     item::Item,
@@ -184,7 +184,7 @@ EqualsValue: Spanned<Value> = {
 
 // Function
 FuncParam: Spanned<FuncParam> = {
-    <l: @L> <name: Name> ":" <ty: Type> <r: @R> => Spanned::new(FuncParam::new(name, ty), Span::new(l, r))
+    <l: @L> <label: Name?> <name: Name> ":" <ty: Type> <r: @R> => Spanned::new(FuncParam::new(label, name, ty), Span::new(l, r))
 }
 
 Function = { Spanned<UnspannedFunction> }
@@ -254,9 +254,17 @@ PrefixedValue<L>: Value = {
     <op: PrefixOperator> <rhs: Spanned<PrefixedValue<L>>> => Value::Prefix(op, Box::new(rhs)),
 }
 
+
+FunctionArgLabel: Spanned<String> = {
+    <name: Name> ":" => name,
+}
+FunctionArg: CallArg = {
+    <label: FunctionArgLabel?> <value: NonStatementLikeValue> => CallArg { label, value }
+}
+
 SuffixedValue<L>: Value = {
     AtomValue<L> => <>,
-    <func: Spanned<SuffixedValue<L>>> "(" <args: CommaList<Value>> ")" => Value::Call(Box::new(func), args),
+    <func: Spanned<SuffixedValue<L>>> "(" <args: CommaList<FunctionArg>> ")" => Value::Call(Box::new(func), args),
     <parent: Spanned<SuffixedValue<L>>> "." <member: PathSegment> => Value::member(Box::new(parent), member),
     <parent: Spanned<SuffixedValue<L>>> "." <index: Spanned<Number>> => Value::TupleMember(Box::new(parent), index),
 }

--- a/tests/Overloading/Functions.fly
+++ b/tests/Overloading/Functions.fly
@@ -1,0 +1,14 @@
+module Test.Overloading
+
+func main() {
+  log(number: 1);
+  log(text: "Hello")
+}
+
+func log(number a: int) {
+  print(format_int(a))
+}
+
+func log(text a: string) {
+  print(a)
+}

--- a/tests/Overloading/FunctionsErrors.fly
+++ b/tests/Overloading/FunctionsErrors.fly
@@ -1,0 +1,15 @@
+module Test.Overloading
+
+func main() {
+  log(number: 1);
+  log(text: "Hello");
+  log(number: 1, text: "Hello")
+}
+
+func log(number a: int) {
+  print(format_int(a))
+}
+
+func log(text a: string) {
+  print(a)
+}

--- a/tests/Overloading/Labels.fly
+++ b/tests/Overloading/Labels.fly
@@ -1,0 +1,9 @@
+module Test.Overloading
+
+func main() {
+  print(format_int(addition(left: 3, right: 2)))
+}
+
+func addition(left a: int, right b: int) -> int {
+  return a + b
+}

--- a/tests/Overloading/Methods.fly
+++ b/tests/Overloading/Methods.fly
@@ -1,0 +1,20 @@
+module Test.Overloading
+
+func main() {
+  var logger = Logger();
+  
+  logger.log(number: 1);
+  logger.log(text: "Hello")
+}
+
+
+
+public struct Logger {
+  func log(number a: int) {
+    print(format_int(a))
+  }
+
+  func log(text a: string) {
+    print(a)
+  }
+}


### PR DESCRIPTION
# Argument Labels

Argument labels allow functions to specify what their arguments are for. These labels must be used when calling the function.

## Declaring Functions with Argument Labels

A function signature contains a list of parameters it takes. A parameter is declared like this: `name: Type`. A parameter is given a label by writing the label name before the declaration, like this: `label name: Type`. If the label and the name are the same, a shortcut of a underscore can be used for the label. A function with a mixture of all three styles would look like this:

```
func readAll(
  parentId: String,

  color c: Color,

  _ page: Int,
  _ pageSize: Int,
)
```

## Calling Functions with Argument Labels

There are two proposals for calling functions with argument labels. We are considering using swift-style colons, and python-style equals signs.

### Colon Style

Calling the `readAll` function with colon style would look like this:

```
readAll(id, color: .Red, page: 1, pageSize: 25)
```

When used as a markup style element, it would look like this:

```
Stack(
  gap: 4,
  alignment: .Center,
  justify: .Center
)
```

#### Advantages

- Easier to parse
- Less visual noise

#### Disadvantages

- Labels blend in more
- Looks worse for markup

### Equals Style

The two examples in equals style would look like this:

```
readAll(id, color = .Red, page = 1, pageSize = 25)
```

```
Stack(
  gap = 4,
  alignment = .Center,
  justify = .Center,
)
```

## Semantics of Argument Labels

Arguments must still be passed in the same order they are defined. If the wrong label is provided for an argument, or no label is provided when one is requested or vice versa, the compiler provides an error like this:

Error: expected argument label `label`, found `found label`.
Error: expected no argument label, found `found label`.
Error: expected argument label `label`, found none.

The compiler won't search the function for similar labels.
